### PR TITLE
Custom types

### DIFF
--- a/examples/m.rizz
+++ b/examples/m.rizz
@@ -1,0 +1,25 @@
+type MyOption 'a =
+    | MNothing
+    | MJust('a)
+
+fun some x : 'a -> MyOption 'a = MJust (x)
+
+fun opt_map f x =
+    match x with
+    | MNothing -> MNothing
+    | MJust (x) -> MJust (f x)
+
+fun opt_map2 f x =
+    match x with
+    | Nothing -> Nothing
+    | Just (x) -> Just (f x)
+
+fun opt_get x =
+    match x with
+    | MJust (x) -> x
+
+fun entry x = 
+    match [ opt_get (opt_map (fun y -> y + 1) (some 10)) ] with
+    | [] -> 0
+    | [x] -> x
+    | _ -> 1

--- a/examples/result.rizz
+++ b/examples/result.rizz
@@ -1,0 +1,29 @@
+type Result 'ok 'err =
+    | Ok ('ok)
+    | Err ('err)
+
+fun ok x = Ok (x)
+fun err x = Err (x)
+
+fun opt_to_result o err_f =
+    match o with
+    | Nothing -> Err (err_f ())
+    | Just (x) -> Ok (x)
+
+fun result_map f r =
+    match r with
+    | Ok (x) -> Ok (f x)
+    | Err (_) -> r
+
+fun result_bind f r =
+    match r with
+    | Ok (x) -> f x
+    | _ -> r
+
+fun result_iter f r = 
+    match r with
+    | Ok (x) -> f x
+    | _ -> ()
+
+fun entry x = 
+    result_map (fun x -> x + 1) (opt_to_result (Just (10)) (fun unit -> 0))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "run:lsp": "opam exec -- dune exec rizzolsp",
         "ext:install:nobuild": "cd vscode-rizzo-lsp && npm run install:local",
         "ext:install": "npm run build && npm run ext:install:nobuild",
+        "ext:install:deps": "cd vscode-rizzo-lsp && npm install",
         "transpile": "gcc -I./src/runtime output.c -o output || clang -I./src/runtime output.c -o output",
         "rizzo": "npm run transpile && ./output",
         "rizz": "npm run rizzo"

--- a/src/lib/ast.ml
+++ b/src/lib/ast.ml
@@ -3,6 +3,7 @@ include Ast_private.Ast_core
 module Core = Ast_private.Ast_core
 module Eq = Ast_private.Ast_eq
 module Pp = Ast_private.Ast_pp
+module Factory = Ast_private.Ast_factory
 
 let eq_expr = Ast_private.Ast_eq.eq_expr
 let eq_name = Ast_private.Ast_eq.eq_name

--- a/src/lib/ast.mli
+++ b/src/lib/ast.mli
@@ -5,3 +5,4 @@ include module type of Ast_private.Ast_pp
 module Core = Ast_private.Ast_core
 module Eq = Ast_private.Ast_eq
 module Pp = Ast_private.Ast_pp
+module Factory = Ast_private.Ast_factory

--- a/src/lib/ast_helpers.ml
+++ b/src/lib/ast_helpers.ml
@@ -40,4 +40,3 @@ and free_vars_expr top_decl_names e : StringSet.t =
       branches
   | EFun (params, body, _) -> free_vars_fun top_decl_names params body
   | EAnno (e, _, _) -> free_vars_expr e
-

--- a/src/lib/ast_private/ast_core.ml
+++ b/src/lib/ast_private/ast_core.ml
@@ -28,6 +28,7 @@ type typ =
   | TString
   | TBool
   | TName of string
+  | TApp of typ * typ list
   | TParam of string
   | TVar of int
   | TFun of typ list1 * typ
@@ -35,9 +36,6 @@ type typ =
   | TSignal of typ
   | TLater of typ
   | TDelay of typ
-  | TSync of typ * typ
-  | TOption of typ
-  | TList of typ
   | TChan of typ
 
 type parsed

--- a/src/lib/ast_private/ast_core.ml
+++ b/src/lib/ast_private/ast_core.ml
@@ -76,9 +76,11 @@ and _ expr =
 
 and 's case_branch = 's pattern * 's expr * 's ann
 and 's name = string * 's ann
+and 's ctor_def = 's name * typ list * 's ann
 
 type _ top_expr =
   | TopLet : 's name * 's expr * 's ann -> 's top_expr
+  | TopTypeDef : 's name * 's name list * 's ctor_def list * 's ann -> 's top_expr
 
 type 'stage program = 'stage top_expr list
 

--- a/src/lib/ast_private/ast_eq.ml
+++ b/src/lib/ast_private/ast_eq.ml
@@ -42,13 +42,13 @@ and eq_typ a b =
   | TVar v1, TVar v2 -> v1 = v2
   | TFun (Cons1 (p1, p_rest1), r1), TFun (Cons1 (p2, p_rest2), r2) ->
     eq_typ p1 p2 && eq_typ r1 r2 && List.length p_rest1 = List.length p_rest2 && List.for_all2 eq_typ p_rest1 p_rest2
-  | TTuple (a1, b1), TTuple (a2, b2) | TSync (a1, b1), TSync (a2, b2) -> eq_typ a1 a2 && eq_typ b1 b2
+  | TTuple (a1, b1), TTuple (a2, b2) -> eq_typ a1 a2 && eq_typ b1 b2
   | TSignal t1, TSignal t2
   | TLater t1, TLater t2
   | TDelay t1, TDelay t2
-  | TOption t1, TOption t2
-  | TList t1, TList t2
   | TChan t1, TChan t2 -> eq_typ t1 t2
+  | TApp (t1, ts1), TApp (t2, ts2) ->
+    eq_typ t1 t2 && List.length ts1 = List.length ts2 && List.for_all2 eq_typ ts1 ts2
   | _ -> false
 
 let eq_top_expr a b =

--- a/src/lib/ast_private/ast_eq.ml
+++ b/src/lib/ast_private/ast_eq.ml
@@ -54,6 +54,16 @@ and eq_typ a b =
 let eq_top_expr a b =
   match a, b with
   | TopLet (x1, e1, _), TopLet (x2, e2, _) -> eq_name x1 x2 && eq_expr e1 e2
+  | TopTypeDef (name1, params1, ctors1, _), TopTypeDef (name2, params2, ctors2, _) ->
+    eq_name name1 name2
+    && List.length params1 = List.length params2
+    && List.for_all2 eq_name params1 params2
+    && List.length ctors1 = List.length ctors2
+    && List.for_all2 (fun (ctor_name1, arg_types1, _) (ctor_name2, arg_types2, _) ->
+         eq_name ctor_name1 ctor_name2
+         && List.length arg_types1 = List.length arg_types2
+         && List.for_all2 eq_typ arg_types1 arg_types2) ctors1 ctors2
+  | _ -> false
 
 let eq_program a b =
   List.length a = List.length b && List.for_all2 eq_top_expr a b

--- a/src/lib/ast_private/ast_factory.ml
+++ b/src/lib/ast_private/ast_factory.ml
@@ -1,0 +1,16 @@
+open! Ast_core
+
+let typ_option t = TApp (TName "Option", [t])
+let typ_list t = TApp (TName "List", [t])
+let typ_sync a b = TApp (TName "Sync", [a; b])
+
+let typ_fun params ret = TFun (Cons1 (List.hd params, List.tl params), ret)
+let typ_fun1 p ret = TFun (Cons1 (p, []), ret)
+let typ_param n = TParam n
+
+let typ_tuple t1 t2 = TTuple (t1, t2)
+
+let typ_signal t = TSignal t
+let typ_later t = TLater t
+let typ_delay t = TDelay t
+let typ_chan t = TChan t

--- a/src/lib/ast_private/ast_pp.ml
+++ b/src/lib/ast_private/ast_pp.ml
@@ -75,10 +75,19 @@ and pp_typ fmt =
   | TTuple (t1, t2) -> fprintf fmt "(%a * %a)" pp_typ t1 pp_typ t2
   | TChan t -> fprintf fmt "(@{<green>Chan@} %a)" pp_typ t
   | TVar i -> fprintf fmt "@{<green>`weak%d@}" i
-  | TApp (t, ts) -> fprintf fmt "@{<green>%a@}(@[<hov>%a@])" pp_typ t (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt ", ") pp_typ) ts
+  | TApp (t, ts) -> fprintf fmt "@{<green>%a@} @[<hov>%a@]" pp_typ t (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt " ") pp_typ) ts
 
 let pp_top_expr out = function
   | TopLet ((x, _), e, _) -> Format.fprintf out "@[<v 2>@{<magenta>let@} @{<lightcyan>%s@} =@,%a@]" x pp_expr e
+  | TopTypeDef ((tname,_), params, ctors, _) ->
+    Format.fprintf out "@[<v 2>@{<magenta>type@} @{<green>%s@} @{<lightcyan>%a@} =@,%a@]"
+      tname
+      (Format.pp_print_list ~pp_sep:(fun out () -> Format.fprintf out " ") (fun out (param, _) -> Format.fprintf out "@{<lightcyan>%s@}" param))
+      params
+      (Format.pp_print_list ~pp_sep:(fun out () -> Format.fprintf out "@,") (fun out ((ctor_name,_), arg_types, _) ->
+         Format.fprintf out "@{<green>%s@}(@[<hov>%a@])" ctor_name
+           (Format.pp_print_list ~pp_sep:(fun out () -> Format.fprintf out ", ") pp_typ) arg_types))
+      ctors
 
 let pp_program out (p : _ program) =
   let open Format in
@@ -97,6 +106,8 @@ and pp_typed_top_expr out : typed top_expr -> unit = function
     Format.fprintf out "@[<v 2>@{<magenta>let@} @{<lightcyan>%s@} : %a =@,%a@]" x pp_typ t pp_typed_expr e
   | TopLet ((x, _), e, _) ->
     Format.fprintf out "@[<v 2>@{<magenta>let@} @{<lightcyan>%s@} =@,%a@]" x pp_expr e
+  | TopTypeDef _ as e -> 
+    Format.fprintf out "%a" pp_top_expr e
 
 and pp_typed_expr out : typed expr -> unit =
   let open Format in

--- a/src/lib/ast_private/ast_pp.ml
+++ b/src/lib/ast_private/ast_pp.ml
@@ -73,11 +73,9 @@ and pp_typ fmt =
   | TParam n -> fprintf fmt "@{<green>%s@}" n
   | TSignal t -> fprintf fmt "(@{<green>Signal@} %a)" pp_typ t
   | TTuple (t1, t2) -> fprintf fmt "(%a * %a)" pp_typ t1 pp_typ t2
-  | TSync (t1, t2) -> fprintf fmt "@{<green>Sync@}(%a, %a)" pp_typ t1 pp_typ t2
-  | TOption t -> fprintf fmt "(@{<green>Option@} %a)" pp_typ t
-  | TList t -> fprintf fmt "(@{<green>List@} %a)" pp_typ t
   | TChan t -> fprintf fmt "(@{<green>Chan@} %a)" pp_typ t
   | TVar i -> fprintf fmt "@{<green>`weak%d@}" i
+  | TApp (t, ts) -> fprintf fmt "@{<green>%a@}(@[<hov>%a@])" pp_typ t (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt ", ") pp_typ) ts
 
 let pp_top_expr out = function
   | TopLet ((x, _), e, _) -> Format.fprintf out "@[<v 2>@{<magenta>let@} @{<lightcyan>%s@} =@,%a@]" x pp_expr e

--- a/src/lib/language_service.ml
+++ b/src/lib/language_service.ml
@@ -90,6 +90,7 @@ type analysis_result = {
 
 type parsed_typed_result = {
   typed_program: Ast.typed Ast.program;
+  type_definitions: Type_env.typedefinition_env;
   diagnostics: diagnostic list;
 }
 
@@ -310,11 +311,16 @@ let parse_with_filename ~(filename : string) (text : string) : (parsed_typed_res
     let parsed = Source_units.parse_document_with_default_prelude ~exclude_paths:[filename] ~filename text in
     let validation_errors = Source_units.validate_program parsed in
     if validation_errors <> [] then
-      Ok { typed_program = []; diagnostics = List.map diagnostic_of_type_error validation_errors }
+      Ok
+        {
+          typed_program = [];
+          type_definitions = Type_env.empty_env.typedefinitions;
+          diagnostics = List.map diagnostic_of_type_error validation_errors;
+        }
     else
-      let typed_program, type_errors = Typecheck.typecheck parsed in
+      let { typed_program; type_definitions; type_errors } : Typecheck.typing_result = Typecheck.typecheck parsed in
       let diagnostics = List.map diagnostic_of_type_error type_errors in
-      Ok { typed_program; diagnostics }
+      Ok { typed_program; type_definitions; diagnostics }
   with
   | Lexer.Error (loc, msg) ->
       Error
@@ -1032,37 +1038,45 @@ let builtin_completion_symbols : completion_symbol StringMap.t =
     StringMap.empty
       Rizzo_builtins.public_builtins
 
-let constructor_completion_specs : (string * Ast.typ) list =
-  [
-    (* ("Just", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", []), Ast.TOption (Ast.TParam "'a")));
-    ("Nothing", Ast.TOption (Ast.TParam "'a")); *)
-    (* ("Cons", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TList (Ast.TParam "'a")]), Ast.TList (Ast.TParam "'a")));
-    ("Nil", Ast.TList (Ast.TParam "'a"));
-    ("Left", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", []), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b")));
-    ("Right", Ast.TFun (Ast.Cons1 (Ast.TParam "'b", []), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b")));
-    ("Both", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TParam "'b"]), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b"))); *)
-  ]
-
-let constructor_completion_symbols : completion_symbol StringMap.t =
-  let empty_range =
-    {
-      start_pos = { line = 0; character = 0 };
-      end_pos = { line = 0; character = 0 };
-    }
+let constructor_completion_symbol_of_definition
+    ~(type_definitions : Type_env.typedefinition_env)
+    ({ arg_types; result_typ; _ } : Type_env.constructor_defintion) : completion_symbol =
+  let result_type =
+    match StringMap.find_opt result_typ type_definitions.types with
+    | Some type_definition ->
+        if type_definition.type_params = [] then
+          Ast.TName result_typ
+        else
+          Ast.TApp
+            (Ast.TName result_typ, List.map (fun type_param -> Ast.TParam type_param) type_definition.type_params)
+    | None -> Ast.TName result_typ
   in
-  List.fold_left
-    (fun env (name, typ) ->
+  let typ =
+    match arg_types with
+    | [] -> result_type
+    | first_arg :: rest_args -> Ast.TFun (Ast.Cons1 (first_arg, rest_args), result_type)
+  in
+  {
+    kind = SemanticType;
+    range =
+      {
+        start_pos = { line = 0; character = 0 };
+        end_pos = { line = 0; character = 0 };
+      };
+    detail = Some (string_of_typ typ);
+    source = CompletionConstructor;
+  }
+
+let constructor_completion_symbols_of_typedefinitions
+    ~(type_definitions : Type_env.typedefinition_env) : completion_symbol StringMap.t =
+  StringMap.fold
+    (fun _ (constructor_definition : Type_env.constructor_defintion) env ->
       completion_add_prefer_high_priority
-        name
-        {
-          kind = SemanticType;
-          range = empty_range;
-          detail = Some (string_of_typ typ);
-          source = CompletionConstructor;
-        }
+        constructor_definition.name
+        (constructor_completion_symbol_of_definition ~type_definitions constructor_definition)
         env)
+    type_definitions.constructors
     StringMap.empty
-    constructor_completion_specs
 
 let completion_prefix_at_position ~(text : string) ~(position : position) : string =
   let lines = lines_of_text text in
@@ -1138,11 +1152,14 @@ let completions_at_position
   let active_filename = file_name ~uri ~filename in
   match parse_with_filename ~filename:active_filename text with
   | Error _ -> completion_empty_list
-  | Ok { typed_program = program; _ } ->
+  | Ok { typed_program = program; type_definitions; _ } ->
       let _ = uri in
       let base_env =
         let with_constructors =
-          StringMap.fold completion_add_prefer_high_priority constructor_completion_symbols builtin_completion_symbols
+          StringMap.fold
+            completion_add_prefer_high_priority
+            (constructor_completion_symbols_of_typedefinitions ~type_definitions)
+            builtin_completion_symbols
         in
         List.fold_left
           (fun env (top : Ast.typed Ast.top_expr) ->

--- a/src/lib/language_service.ml
+++ b/src/lib/language_service.ml
@@ -1034,13 +1034,13 @@ let builtin_completion_symbols : completion_symbol StringMap.t =
 
 let constructor_completion_specs : (string * Ast.typ) list =
   [
-    ("Just", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", []), Ast.TOption (Ast.TParam "'a")));
-    ("Nothing", Ast.TOption (Ast.TParam "'a"));
-    ("Cons", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TList (Ast.TParam "'a")]), Ast.TList (Ast.TParam "'a")));
+    (* ("Just", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", []), Ast.TOption (Ast.TParam "'a")));
+    ("Nothing", Ast.TOption (Ast.TParam "'a")); *)
+    (* ("Cons", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TList (Ast.TParam "'a")]), Ast.TList (Ast.TParam "'a")));
     ("Nil", Ast.TList (Ast.TParam "'a"));
     ("Left", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", []), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b")));
     ("Right", Ast.TFun (Ast.Cons1 (Ast.TParam "'b", []), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b")));
-    ("Both", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TParam "'b"]), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b")));
+    ("Both", Ast.TFun (Ast.Cons1 (Ast.TParam "'a", [Ast.TParam "'b"]), Ast.TSync (Ast.TParam "'a", Ast.TParam "'b"))); *)
   ]
 
 let constructor_completion_symbols : completion_symbol StringMap.t =

--- a/src/lib/language_service.ml
+++ b/src/lib/language_service.ml
@@ -424,6 +424,7 @@ let top_level_declarations : type s.
           let top_range = range_of_ann ann in
           let selection_range = range_of_name top_name in
           Some (name, kind, filename, top_range, selection_range)
+        | Ast.TopTypeDef _ -> None
   in
   List.filter_map declaration_of_top program
 
@@ -467,6 +468,7 @@ let top_level_declarations : type s.
         let visit_top = function
           | Ast.TopLet (_, rhs, ann) when ann_in_file ~filename ann -> iter_expr push rhs
           | Ast.TopLet _ -> ()
+          | Ast.TopTypeDef _ -> ()
         in
         List.iter visit_top program;
         !acc
@@ -493,6 +495,11 @@ let type_info_block_of_typ_opt (typ : Ast.typ option) : string =
 
 let type_info_block_of_ann : type s. s Ast.ann -> string =
   fun ann -> type_info_block_of_typ_opt (typ_of_ann_opt ann)
+
+let top_level_type_definition_text : type s. s Ast.top_expr -> string =
+  fun top ->
+    let top_text = Format.asprintf "%a" Ast.pp_top_expr top |> dedent_text in
+    Format.asprintf "\n\nType definition:\n```rizz\n%s\n```" top_text
 
 let hover_text_for_named_symbol : type s. label:string -> s Ast.name -> string =
   fun ~label (name, ann) ->
@@ -638,21 +645,20 @@ let rec pattern_hover_at_position : type s. position:position -> s Ast.pattern -
         else
           List.find_map (pattern_hover_at_position ~position) args
 
+let keyword_range_from_start ~(name : string) ~(start_pos : position) : range =
+  {
+    start_pos;
+    end_pos =
+      {
+        line = start_pos.line;
+        character = start_pos.character + String.length name;
+      };
+  }
+
 let keyword_range_from_expr : type s. name:string -> s Ast.expr -> range option =
   fun ~name expr ->
-  let expr_range = range_of_ann (Ast.expr_get_ann expr) in
-  if expr_range.start_pos.line <> expr_range.end_pos.line then
-    None
-  else
-    Some
-      {
-        start_pos = expr_range.start_pos;
-        end_pos =
-          {
-            line = expr_range.start_pos.line;
-            character = expr_range.start_pos.character + String.length name;
-          };
-      }
+    let expr_range = range_of_ann (Ast.expr_get_ann expr) in
+    Some (keyword_range_from_start ~name ~start_pos:expr_range.start_pos)
 
 let semantic_kind_of_symbol_kind = function
   | Function -> SemanticFunction
@@ -831,6 +837,7 @@ let definition_at_position ~(uri : string) ~(filename : string option) ~(text : 
       let rec find_in_tops tops =
         match tops with
         | [] -> None
+        | Ast.TopTypeDef _ :: rest -> find_in_tops rest
         | Ast.TopLet (top_name, rhs, ann) :: rest ->
             if not (ann_in_file ~filename:active_filename ann) then
               find_in_tops rest
@@ -869,6 +876,15 @@ let hover_at_position ~(uri : string) ~(filename : string option) ~(text : strin
                       | Variable -> "top-level binding: " ^ name_text top_name
                     in
                     Some { range = name_range; contents = base ^ type_info_block_of_ann top_ann }
+                  else
+                    None
+            | Ast.TopTypeDef (_, _, _, top_ann) as top_def ->
+                if not (ann_in_file ~filename:active_filename top_ann) then
+                  None
+                else
+                  let top_range = range_of_ann top_ann in
+                  if range_contains_position top_range position then
+                    Some { range = top_range; contents = top_level_type_definition_text top_def }
                   else
                     None)
           program
@@ -954,7 +970,8 @@ let hover_at_position ~(uri : string) ~(filename : string option) ~(text : strin
                     if ann_in_file ~filename:active_filename top_ann then
                       find_symbol_hover_in_expr rhs
                     else
-                      None)
+                      None
+                | Ast.TopTypeDef _ -> None)
               program
           in
           match symbol_hover with
@@ -1169,7 +1186,8 @@ let completions_at_position
                 completion_add_prefer_high_priority
                   (name_text top_name)
                   (completion_symbol_of_name ~source:CompletionTopLevel ~kind top_name)
-                  env)
+                  env
+            | Ast.TopTypeDef _ -> env)
           with_constructors
           program
       in
@@ -1313,6 +1331,7 @@ let completions_at_position
                  | None -> Some base_env)
             else
               env_in_tops rest
+        | Ast.TopTypeDef _ :: rest -> env_in_tops rest
       in
       let env =
         match env_in_tops program with
@@ -1438,6 +1457,7 @@ let semantic_tokens ~(uri : string) ~(filename : string option) ~(text : string)
       in
       List.iter
         (function
+          | Ast.TopTypeDef _ -> ()
           | Ast.TopLet (top_name, rhs, ann) ->
               if ann_in_file ~filename:active_filename ann then
                 let name = name_text top_name in

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -78,10 +78,7 @@ rule read = parse
     match x with
     | "Later" -> TYPE_LATER
     | "Delay" -> TYPE_DELAY
-    | "Sync" -> TYPE_SYNC
     | "Signal" -> TYPE_SIGNAL
-    | "Option" -> TYPE_OPTION
-    | "List" -> TYPE_LIST
     | _ -> TYPE_ID x 
     }
   | int as i { INT (int_of_string i) }

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -109,6 +109,7 @@ rule read = parse
       | "if" -> IF
       | "then" -> THEN
       | "else" -> ELSE
+      | "type" -> TYPE
       | _ -> ID x
     }
   | eof { EOF }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -67,7 +67,7 @@ let rec list_pattern_of_list start_pos end_pos = function
 *)
 %}
 
-%token LET FUN MATCH WITH IN
+%token LET FUN MATCH WITH IN TYPE
 %token EFFECTFUL
 %token EQ CONS COMMA LPAREN RPAREN LBRACKET RBRACKET BAR
 %token IF THEN ELSE
@@ -119,6 +119,22 @@ top_expr:
       | None -> TopLet (top_name, EFun (params, body, mkloc $startpos(params) $endpos(body)), mkloc $symbolstartpos $endpos(body))
       | Some te -> TopLet (top_name, EAnno(EFun (params, body, mkloc $startpos(params) $endpos(body)), te, mkloc $startpos(body) $endpos(body)), mkloc $symbolstartpos $endpos(body))
     }
+  | TYPE type_name=TYPE_ID type_params=type_param_names EQ BAR? type_ctors=separated_nonempty_list(BAR, type_ctor)
+    { let type_name = (type_name, mkloc $startpos(type_name) $endpos(type_name)) in
+      TopTypeDef (type_name, type_params, type_ctors, mkloc $startpos $endpos) }
+
+(* Separate rule because these need to be converted to names, idk - that's how I encoded it in AST *)
+type_param_names:
+  | { [] }
+  | tv=TYPEVAR type_vars=type_param_names { (tv, mkloc $startpos(tv) $endpos(tv)) :: type_vars }
+
+type_ctor:
+  | ctor_name=TYPE_ID 
+    { let loc = mkloc $startpos(ctor_name) $endpos(ctor_name) in
+      (ctor_name, loc), [], loc }
+  | ctor_name=TYPE_ID LPAREN ctor_args=separated_nonempty_list(COMMA, type_expr) RPAREN
+    { let ctor_name = (ctor_name, mkloc $startpos(ctor_name) $endpos(ctor_name)) in
+      (ctor_name, ctor_args, mkloc $startpos $endpos) }
 
 nonempty_id_list:
   | x=ID { [(x, mkloc $startpos(x) $endpos(x))] }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -73,7 +73,7 @@ let rec list_pattern_of_list start_pos end_pos = function
 %token IF THEN ELSE
 %token PIPE_GT ARROW COLON STAR SLASH PERCENT UNDERSCORE EQEQ PLUS MINUS LT GT LEQ GEQ BANG
 %token NEVER WAIT WATCH TAIL SYNC LATERAPP OSTAR DELAY //NOT
-%token TYPE_SIGNAL TYPE_LATER TYPE_DELAY TYPE_SYNC TYPE_OPTION TYPE_LIST
+%token TYPE_SIGNAL TYPE_LATER TYPE_DELAY
 %token <string> ID
 %token <string> TYPE_ID
 %token <string> TYPEVAR
@@ -322,9 +322,8 @@ app_type:
   | TYPE_SIGNAL ta=type_atom { TSignal ta }
   | TYPE_LATER ta=type_atom { TLater ta }
   | TYPE_DELAY ta=type_atom { TDelay ta }
-  | TYPE_SYNC ta1=type_atom ta2=type_atom { TSync (ta1, ta2) }
-  | TYPE_OPTION ta=type_atom { TOption ta }
-  | TYPE_LIST ta=type_atom { TList ta }
+  // | TYPE_SYNC ta1=type_atom ta2=type_atom { TSync (ta1, ta2) }
+  | at=app_type ta=type_atom+ { TApp (at, ta) }
   | ta=type_atom { ta }
   (* For now just keep it simple - we could certainly add a 'TApp of typ * typ' later  *)
   // | at=app_type ta=type_atoma { failwith "type application ..." }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -335,14 +335,20 @@ prod_type:
   | at=app_type { at }
 
 app_type:
+  // Parse type application in one production so Menhir does not need to guess
+  // whether another type_atom extends the current application or starts a new one.
+  | head=type_apply_head args=type_atom*
+    { match args with
+      | [] -> head
+      | _ -> TApp (head, args) }
+  (* For now just keep it simple - we could certainly add a 'TApp of typ * typ' later  *)
+  // | at=app_type ta=type_atoma { failwith "type application ..." }
+
+type_apply_head:
   | TYPE_SIGNAL ta=type_atom { TSignal ta }
   | TYPE_LATER ta=type_atom { TLater ta }
   | TYPE_DELAY ta=type_atom { TDelay ta }
-  // | TYPE_SYNC ta1=type_atom ta2=type_atom { TSync (ta1, ta2) }
-  | at=app_type ta=type_atom+ { TApp (at, ta) }
   | ta=type_atom { ta }
-  (* For now just keep it simple - we could certainly add a 'TApp of typ * typ' later  *)
-  // | at=app_type ta=type_atoma { failwith "type application ..." }
 
 type_atom:
   | tid=TYPE_ID { 

--- a/src/lib/rizzo_builtins.ml
+++ b/src/lib/rizzo_builtins.ml
@@ -18,6 +18,8 @@ let mk name ?(ownership = None) ?(proj_idx = None) ?(public = true) (t: Ast.typ)
   typ = t;
 }
 
+open Ast.Factory
+
 let output_builtins = [
   mk "console_out_signal" ~ownership:(Some [Refcount_core.Owned]) (TFun (Cons1(TSignal (TParam "'a"), []), TUnit)) ();
   mk "quit_at" ~ownership:(Some [Refcount_core.Owned]) (TFun (Cons1(TLater (TParam "'a"), []), TUnit)) ();
@@ -27,7 +29,7 @@ let output_builtins = [
 let builtins = [
   mk "start_event_loop" ~ownership:(Some [Refcount_core.Borrowed]) (TFun(Cons1(TUnit, []), TUnit)) ();
   mk "clock" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TInt, []), TSignal TInt)) ();
-  mk "parse_int" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TOption TInt)) ();
+  mk "parse_int" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TApp (TName "Option", [TInt]))) ();
   mk "not" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TBool, []), TBool)) ();
   mk "mod" ~ownership:(Some [Refcount_core.Borrowed; Refcount_core.Borrowed]) (TFun (Cons1(TInt, [TInt]), TInt)) ();
   mk "eq" ~ownership:(Some [Refcount_core.Borrowed; Refcount_core.Borrowed]) (TFun (Cons1(TParam "'a", [TParam "'a"]), TBool)) ();
@@ -51,17 +53,17 @@ let builtins = [
   mk "string_is_empty" ~public:false ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TBool)) ();
   mk "string_head" ~public:false ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TString)) ();
   mk "string_tail" ~public:false ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TString)) ();
-  mk "string_split" ~ownership:(Some [Refcount_core.Borrowed; Refcount_core.Borrowed]) (TFun (Cons1(TString, [TString]), TList TString)) ();
-  mk "string_of_int" ~public:true ~ownership: (Some [Refcount_core.Borrowed]) (TFun (Cons1(TInt, []), TString)) ();
-  mk "match_fail" ~public:false ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TString, []), TParam "'a")) ();
+  mk "string_split" ~ownership:(Some [Refcount_core.Borrowed; Refcount_core.Borrowed]) (typ_fun [TString; TString] (typ_list TString)) ();
+  mk "string_of_int" ~public:true ~ownership: (Some [Refcount_core.Borrowed]) (typ_fun [TInt] TString) ();
+  mk "match_fail" ~public:false ~ownership:(Some [Refcount_core.Borrowed]) (typ_fun [TString] (typ_param "'a")) ();
 
-  mk "head" ~proj_idx:(Some 0) (TFun (Cons1(TSignal (TParam "'a"), []), TParam "'a")) ();
-  mk "list_head" ~proj_idx:(Some 0) (TFun (Cons1(TList (TParam "'a"), []), TParam "'a")) ();
-  mk "list_tail" ~proj_idx:(Some 1) (TFun (Cons1(TList (TParam "'a"), []), TList (TParam "'a"))) ();
-  mk "list_is_empty" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TList (TParam "'a"), []), TBool)) ();
-  mk "list_length" ~ownership:(Some [Refcount_core.Borrowed]) (TFun (Cons1(TList (TParam "'a"), []), TInt)) ();
-  mk "fst" ~proj_idx: (Some 0) (TFun (Cons1(TTuple (TParam "'a", TParam "'b"), []), TParam "'a")) ();
-  mk "snd" ~proj_idx: (Some 1) (TFun (Cons1(TTuple (TParam "'a", TParam "'b"), []), TParam "'b")) ();
+  mk "head" ~proj_idx:(Some 0) (typ_fun1 (typ_signal (typ_param "'a")) (typ_param "'a")) ();
+  mk "list_head" ~proj_idx:(Some 0) (typ_fun1 (typ_list (typ_param "'a")) (typ_param "'a")) ();
+  mk "list_tail" ~proj_idx:(Some 1) (typ_fun1 (typ_list (typ_param "'a")) (typ_list (typ_param "'a"))) ();
+  mk "list_is_empty" ~ownership:(Some [Refcount_core.Borrowed]) (typ_fun1 (typ_list (typ_param "'a")) TBool) ();
+  mk "list_length" ~ownership:(Some [Refcount_core.Borrowed]) (typ_fun1 (typ_list (typ_param "'a")) TInt) ();
+  mk "fst" ~proj_idx: (Some 0) (typ_fun1 (typ_tuple (typ_param "'a") (typ_param "'b")) (typ_param "'a")) ();
+  mk "snd" ~proj_idx: (Some 1) (typ_fun1 (typ_tuple (typ_param "'a") (typ_param "'b")) (typ_param "'b")) ();
 
   mk "console" (TChan TString) ();
 

--- a/src/lib/rizzo_builtins.ml
+++ b/src/lib/rizzo_builtins.ml
@@ -93,6 +93,22 @@ let is_builtin_projection name = match M.find_opt name builtins_map with
   | _ -> false
 
 
+let builtin_types = 
+    [ ("Option", ["'a"], [
+        ("Nothing", []);
+        ("Just", [Ast.TParam "'a"]);
+      ])
+    ; ("List", ["'a"], [
+        ("Nil", []);
+        ("Cons", [TParam "'a"; TApp (TName "List", [TParam "'a"])])
+      ])
+    ; ("Sync", ["'a"; "'b"], [
+        ("Left", [TParam "'a"]);
+        ("Right", [TParam "'b"]);
+        ("Both", [TParam "'a"; TParam "'b"])
+      ])
+    ]
+
 (* consider if we can do this in a way that 
   makes the compiler complain if we dont have the entries*)
 let ctor_mappings = 
@@ -124,10 +140,10 @@ let ctor_mappings =
     ("true", 0);
     ("false", 1);
     ("sigcons", -1);
-    ("nothing", 0);
+    (* ("nothing", 0);
     ("just", 1);
     ("nil", 2);
-    ("cons", 3);
+    ("cons", 3); *)
   ]
 
 let ctor_tag_of name = match M.find_opt (String.lowercase_ascii name) ctor_mappings with

--- a/src/lib/rizzoc.ml
+++ b/src/lib/rizzoc.ml
@@ -27,6 +27,16 @@ module RefCount = struct
 include Refcount
 end
 
+module TypeCheck = struct
+  type typing_result = Typecheck.typing_result
+  type type_definition = Type_env.typedefinition
+  type ctor_definition = Type_env.constructor_defintion
+  type type_definition_env = Type_env.typedefinition_env
+
+  let typecheck = Typecheck.typecheck
+  let type_definitions_to_ctor_mappings = Type_env.TypeDefinitionEnv.to_ctor_mappings
+end
+
 module Transformations = struct
   module ANF = struct
     let anf_expr = Transforms.Anf.normalize_expr
@@ -50,8 +60,8 @@ module Transformations = struct
   
   let builtins = Rizzo_builtins.builtins_ownerships_map
   
-  let auto_ref_count (program: Ast.parsed Ast.program) = 
-    let program = ast_to_rc_ir builtins program in
+  let auto_ref_count ctor_mappings (program: Ast.parsed Ast.program) = 
+    let program = ast_to_rc_ir ctor_mappings builtins program in
     RefCount.reference_count_program builtins Rizzo_builtins.builtins_projection_map program
 end
 
@@ -187,8 +197,6 @@ let apply_transforms p =
 
 let ref_count p = Transformations.auto_ref_count p
 
-type typing_result = Typecheck.typing_result
-let typecheck = Typecheck.typecheck
 let lower_typed_program = Transformations.lower_typed_program
 let apply_typed_transforms p = p |> lower_typed_program |> apply_transforms
 
@@ -253,7 +261,7 @@ and compile parsed_program output_file =
     | _ -> raise (Source_units.Validation_failed validation_errors)
     );
     if !print_ast_dumps then print_section "------- Parsed -------" Ast.pp_program parsed_program;
-		let {typed_program = typed; type_errors = errors; _} : Typecheck.typing_result = typecheck parsed_program in
+		let {typed_program = typed; type_errors = errors; type_definitions} : TypeCheck.typing_result = TypeCheck.typecheck parsed_program in
 		(match errors with
     | [] -> if !print_ast_dumps then print_section "------- Type checked -------" Ast.pp_typed_program typed
 		| _ ->
@@ -267,7 +275,8 @@ and compile parsed_program output_file =
 		);
     let transformed = apply_typed_transforms typed in
     if !print_ast_dumps then print_section "------- Transformed -------" Ast.pp_program transformed;
-    let rc_env, rc_program = ref_count transformed in
+    let ctor_mappings = TypeCheck.type_definitions_to_ctor_mappings type_definitions in
+    let rc_env, rc_program = ref_count ctor_mappings transformed in
     if !print_ast_dumps then print_section "------- Reference counted -------" (RefCount.pp_ref_counted_program ~ownerships:(Some rc_env)) rc_program;
 		emit rc_program output_file
 	with

--- a/src/lib/rizzoc.ml
+++ b/src/lib/rizzoc.ml
@@ -187,6 +187,7 @@ let apply_transforms p =
 
 let ref_count p = Transformations.auto_ref_count p
 
+type typing_result = Typecheck.typing_result
 let typecheck = Typecheck.typecheck
 let lower_typed_program = Transformations.lower_typed_program
 let apply_typed_transforms p = p |> lower_typed_program |> apply_transforms
@@ -252,7 +253,7 @@ and compile parsed_program output_file =
     | _ -> raise (Source_units.Validation_failed validation_errors)
     );
     if !print_ast_dumps then print_section "------- Parsed -------" Ast.pp_program parsed_program;
-		let (typed, errors) = typecheck parsed_program in
+		let {typed_program = typed; type_errors = errors; _} : Typecheck.typing_result = typecheck parsed_program in
 		(match errors with
     | [] -> if !print_ast_dumps then print_section "------- Type checked -------" Ast.pp_typed_program typed
 		| _ ->

--- a/src/lib/source_units.ml
+++ b/src/lib/source_units.ml
@@ -78,7 +78,9 @@ let validate_program (program : _ Ast.program) =
   let seen = Hashtbl.create 32 in
   let errors = ref [] in
   List.iter
-    (fun (Ast.TopLet ((name, name_ann), _, _)) ->
+    (function
+    | Ast.TopTypeDef _ -> ()
+    | Ast.TopLet ((name, name_ann), _, _) ->
       let loc = Ast.get_location name_ann in
       match Hashtbl.find_opt seen name with
       | None -> Hashtbl.add seen name loc

--- a/src/lib/transforms/anf.ml
+++ b/src/lib/transforms/anf.ml
@@ -51,5 +51,8 @@ and normalize_name_mult ms k = match ms with
 | [] -> k []
 | m :: ms -> normalize_name m (fun t -> normalize_name_mult ms (fun t' -> k (t :: t')))
 
-let normalize_program (p: parsed program) : parsed program =
-  List.map (fun (TopLet (x,e, loc)) -> TopLet (x, normalize_expr e, loc)) p
+let normalize_program (p: _ program) : _ program =
+  p |> List.map (function
+    | TopLet (x, e, ann) -> TopLet (x, normalize_expr e, ann)
+    | TopTypeDef _ as e -> e
+  )

--- a/src/lib/transforms/consecutive_lambda.ml
+++ b/src/lib/transforms/consecutive_lambda.ml
@@ -45,4 +45,6 @@ let rec eliminate_consecutive_lambdas_expr (e : _ expr) : _ expr =
   | EAnno (e, t, loc) -> EAnno (eliminate_consecutive_lambdas_expr e, t, loc)
 
 let eliminate_consecutive_lambdas_program (p : _ program) : _ program =
-  List.map (fun (TopLet (x, e, loc)) -> TopLet (x, eliminate_consecutive_lambdas_expr e, loc)) p
+  p |> List.map (function 
+    | TopTypeDef _ as e -> e
+    | TopLet (x, e, loc) -> TopLet (x, eliminate_consecutive_lambdas_expr e, loc))

--- a/src/lib/transforms/copy_propagation.ml
+++ b/src/lib/transforms/copy_propagation.ml
@@ -57,4 +57,7 @@ let eliminate_copy_propagation (e: _ expr) : _ expr =
   aux [] e
 
 let copy_propagate (p: _ program) : _ program =
-  List.map (fun (TopLet (x, e, ann)) -> TopLet(x, eliminate_copy_propagation e, ann)) p
+  p
+  |> List.map (function 
+    | TopTypeDef _ as e -> e
+    | TopLet (x, e, ann) -> TopLet(x, eliminate_copy_propagation e, ann))

--- a/src/lib/transforms/dead_let_elimination.ml
+++ b/src/lib/transforms/dead_let_elimination.ml
@@ -51,4 +51,7 @@ let rec eliminate_dead_let (e : _ expr) : _ expr =
 	| EAnno (e, t, ann) -> EAnno (eliminate_dead_let e, t, ann)
 
 let dead_let_eliminate (p : _ program) : _ program =
-	List.map (fun (TopLet (x, e, ann)) -> TopLet (x, eliminate_dead_let e, ann)) p
+	p
+	|> List.map (function 
+		| TopTypeDef _ as e -> e
+		| TopLet (x, e, ann) -> TopLet (x, eliminate_dead_let e, ann))

--- a/src/lib/transforms/explicit_lifts.ml
+++ b/src/lib/transforms/explicit_lifts.ml
@@ -75,6 +75,8 @@ let make_explicit (program : _ program) : _ program =
     |> StringSet.union builtin_function_names
   in
   List.map
-    (fun (TopLet (name, expr, ann)) ->
+    (function
+    | TopTypeDef _ as e -> e
+    | TopLet (name, expr, ann) ->
       TopLet (name, rewrite_expr function_names StringSet.empty ~as_callee:false expr, ann))
     program

--- a/src/lib/transforms/lambda_lifting.ml
+++ b/src/lib/transforms/lambda_lifting.ml
@@ -5,13 +5,19 @@ open Collections
 
 let rec lift (p: _ program) : _ program =
   let lifted_lambdas = ref [] in
-  let top_decl_names = StringSet.of_list @@ List.map (fun (TopLet(name,_,_)) -> fst name) p in
+  let top_decl_names = 
+    StringSet.of_list (
+      p
+      |> List.filter_map (function 
+      | TopTypeDef _ -> None
+      | TopLet((name, _),_,_) -> Some name))in
   let lifted_program = List.fold_right (fun te acc -> lift_top_expr top_decl_names lifted_lambdas te :: acc) p [] in
   List.rev_append !lifted_lambdas lifted_program
 
 and lift_top_expr top_names (lifted_lambdas: _ top_expr list ref) (te: _ top_expr) : _ top_expr =
   let lift_expr = lift_expr top_names lifted_lambdas in
   match te with
+  | TopTypeDef _ as e -> e
   | TopLet (x, EFun (params, body, fun_loc), let_loc) -> TopLet (x, EFun (params, lift_expr body, fun_loc), let_loc)
   | TopLet (x, EAnno (EFun (params, body, fun_loc), t, annotation_loc), let_loc) ->
     TopLet (x, EAnno (EFun (params, lift_expr body, fun_loc), t, annotation_loc), let_loc)

--- a/src/lib/transforms/patterns.ml
+++ b/src/lib/transforms/patterns.ml
@@ -20,7 +20,10 @@ let match_fail ann message =
 	app (match_fail, ann) [EConst (CString message, ann)]
 
 let rec transform_patterns (program: 's Ast.program) =
-	List.map (fun (TopLet (name, expr, ann)) -> TopLet (name, compile_match expr, ann)) program
+	program 
+	|> List.map (function
+    | TopTypeDef _ as e -> e
+    | (TopLet (name, expr, ann)) -> TopLet (name, compile_match expr, ann))
 
 and compile_pattern p scrutinee good bad =
 	match p with

--- a/src/lib/transforms/patterns_tree.ml
+++ b/src/lib/transforms/patterns_tree.ml
@@ -349,4 +349,7 @@ and compile_match e =
 	| EAnno (e, t, ann) -> EAnno (compile_match e, t, ann)
 
 let transform_patterns (program: 's Ast.program) =
-	List.map (fun (TopLet (name, expr, ann)) -> TopLet (name, compile_match expr, ann)) program
+	program 
+	|> List.map (function
+		| TopLet (name, expr, ann) -> TopLet (name, compile_match expr, ann)
+		| TopTypeDef _ as e -> e)

--- a/src/lib/transforms/pure_to_rc.ml
+++ b/src/lib/transforms/pure_to_rc.ml
@@ -3,6 +3,8 @@ open Ast
 module Rc = Refcount_private.Refcount_core
 module M = Map.Make(String)
 
+open Collections
+
 let get_name = function
   | EVar (x, _) -> Rc.Var x
   | EConst (c, _) -> Rc.Const c
@@ -10,10 +12,12 @@ let get_name = function
   | EAnno (EConst (c, _), _, _) -> Rc.Const c
   | _ -> failwith "get_name failed: expected variable or constant"
 
-let tagof = Rizzo_builtins.ctor_tag_of
-
-let ctor_tag_of_name (name : string) : int =
-  Rizzo_builtins.ctor_tag_of name
+(** Finds the tag of a constructor by first looking in the [user_defined_ctor_mappings] and then in [Rizzo_builtins.ctor_mappings].
+  Throws a runtime failure if [name] is not found in any of the mappings. *)
+let tagof user_defined_ctor_mappings name = 
+  match StringMap.find_opt name user_defined_ctor_mappings with
+  | Some tag -> tag
+  | None -> Rizzo_builtins.ctor_tag_of name
 
 let case_arm ?tag ?num_fields body : Rc.case_arm =
   { tag; num_fields; body }
@@ -35,10 +39,11 @@ type globals_env = int option M.t
 
 module LocalsEnv = Set.Make(String)
 
-let rec expr_to_rexpr globals locals (e : _ expr) : Rc.rexpr =
+let rec expr_to_rexpr ctor_tag_map globals locals (e : _ expr) : Rc.rexpr =
+  let tagof = tagof ctor_tag_map in
   match e with
   | ECtor ((ctor_name, _), args, _) ->
-      RCtor (Ctor { tag = ctor_tag_of_name ctor_name; fields = List.map get_name args })
+      RCtor (Ctor { tag = tagof ctor_name; fields = List.map get_name args })
   | EApp (EVar (f, _), [EVar (x, _)], _) when Rizzo_builtins.is_builtin_projection f ->
       let proj_idx = (Rizzo_builtins.get f).projection_index |> Option.get in
       RProj (proj_idx, x)
@@ -69,7 +74,7 @@ let rec expr_to_rexpr globals locals (e : _ expr) : Rc.rexpr =
   | EUnary (UNot, n, _) -> RCall ("not", [get_name n])
   | EUnary (UProj idx, (EVar (x, _) | EAnno (EVar (x, _), _, _)), _) -> RProj (idx, x)
   | EConst (const, _) -> RConst const
-  | EAnno (inner, _, _) -> expr_to_rexpr globals locals inner
+  | EAnno (inner, _, _) -> expr_to_rexpr ctor_tag_map globals locals inner
   | _ -> failwith (Format.asprintf "expr_to_rexpr failed: invalid expression '%a'" Ast.pp_expr e)
 
 and convert_var_apps f args x body : Rc.fn_body =
@@ -86,7 +91,10 @@ and constant_needs_split (globals : int option M.t) f args =
   Option.bind (M.find_opt f globals) (Option.map (fun i -> i < List.length args))
   |> Option.value ~default:false
 
-and app_to_fn_body globals locals = function
+and app_to_fn_body ctor_tag_map globals locals = 
+  let expr_to_rexpr_partial = expr_to_rexpr ctor_tag_map globals in
+  let expr_to_fn_body_partial = expr_to_fn_body ctor_tag_map globals in 
+  function
   | EApp (EVar (f, _), args, _) when LocalsEnv.mem f locals ->
       let final_name = Utilities.new_var () in
       convert_var_apps f args final_name (FnRet (Var final_name))
@@ -104,32 +112,33 @@ and app_to_fn_body globals locals = function
       let var_apps_body = convert_var_apps proj_var rest apps_variable (FnRet (Var apps_variable)) in
       FnLet (proj_var, Rc.RProj (proj_idx, x), var_apps_body)
   | ELet ((x, _), EApp (EVar (f, _), args, _), body, _) when LocalsEnv.mem f locals ->
-      let body = expr_to_fn_body globals (LocalsEnv.add x locals) body in
+      let body = expr_to_fn_body_partial (LocalsEnv.add x locals) body in
       convert_var_apps f args x body
   | ELet ((x, _), EApp (EVar (f, _), args, _), body, _) when constant_needs_split globals f args ->
       let arity = M.find_opt f globals |> Option.get |> Option.get in
       let args_constant = List.take arity args |> List.map get_name in
       let constant_app_var = Utilities.new_var () in
-      let body = expr_to_fn_body globals (LocalsEnv.add x locals) body in
+      let body = expr_to_fn_body_partial (LocalsEnv.add x locals) body in
       let var_apps_body = convert_var_apps constant_app_var (List.drop arity args) x body in
       FnLet (constant_app_var, Rc.RCall (f, args_constant), var_apps_body)
   | ELet ((vx, _), EApp (EVar (f, _), EVar (x, _) :: (_ :: _ as rest), _), body, _) when Rizzo_builtins.is_builtin_projection f ->
       let proj_idx = (Rizzo_builtins.get f).projection_index |> Option.get in
       let proj = Rc.RProj (proj_idx, x) in
       let proj_var = Utilities.new_var () in
-      let body = expr_to_fn_body globals (LocalsEnv.add vx locals) body in
+      let body = expr_to_fn_body_partial (LocalsEnv.add vx locals) body in
       let var_apps_body = convert_var_apps proj_var rest vx body in
       FnLet (proj_var, proj, var_apps_body)
   | ELet ((x, _), rhs, body, _) ->
-      FnLet (x, expr_to_rexpr globals locals rhs, expr_to_fn_body globals (LocalsEnv.add x locals) body)
+      FnLet (x, expr_to_rexpr_partial locals rhs, expr_to_fn_body_partial (LocalsEnv.add x locals) body)
   | expr ->
       let x = Utilities.new_var () in
-      FnLet (x, expr_to_rexpr globals locals expr, FnRet (Rc.Var x))
+      FnLet (x, expr_to_rexpr_partial locals expr, FnRet (Rc.Var x))
 
-and expr_to_fn_body globals locals (e : _ expr) : Rc.fn_body =
-  let expr_to_fn_body = expr_to_fn_body globals in
-  let expr_to_rexpr = expr_to_rexpr globals in
+and expr_to_fn_body ctor_tag_map globals locals (e : _ expr) : Rc.fn_body =
+  let expr_to_fn_body = expr_to_fn_body ctor_tag_map globals in
+  let expr_to_rexpr = expr_to_rexpr ctor_tag_map globals in
   let lower_case_arm (pattern, branch, _) =
+    let tagof = tagof ctor_tag_map in
     let body = expr_to_fn_body locals branch in
     match pattern with
     | PVar _ | PWildcard _ -> case_arm body
@@ -142,7 +151,7 @@ and expr_to_fn_body globals locals (e : _ expr) : Rc.fn_body =
     | PTuple _ -> case_arm ~tag:(tagof "tuple") ~num_fields:2 body
     | PSigCons _ -> case_arm ~tag:0 ~num_fields:5 body
     | PStringCons _ -> failwith "String patterns should be eliminated before RC lowering"
-    | PCtor ((ctor_name, _), args, _) -> case_arm ~tag:(ctor_tag_of_name ctor_name) ~num_fields:(List.length args) body
+    | PCtor ((ctor_name, _), args, _) -> case_arm ~tag:(tagof ctor_name) ~num_fields:(List.length args) body
   in
   let lower_case_arms cases =
     let rec aux seen_tags acc = function
@@ -159,13 +168,13 @@ and expr_to_fn_body globals locals (e : _ expr) : Rc.fn_body =
   match e with
   | EVar (x, _) -> FnRet (Var x)
   | EConst (c, _) -> FnRet (Const c)
-  | EApp _ | ELet _ -> app_to_fn_body globals locals e
+  | EApp _ | ELet _ -> app_to_fn_body ctor_tag_map globals locals e
   | ECase ((EVar (x, _) | EAnno (EVar (x, _), _, _)), cases, _) -> FnCase (x, lower_case_arms cases)
   | ECase _ -> failwith "expr_to_fn_body failed: case scrutinee is not a variable"
   | EIfe (EVar (x, _), e1, e2, _) ->
       FnCase (x, [
-        case_arm ~tag:(tagof "true") ~num_fields:0 (expr_to_fn_body locals e1);
-        case_arm ~tag:(tagof "false") ~num_fields:0 (expr_to_fn_body locals e2)
+        case_arm ~tag:(tagof ctor_tag_map "true") ~num_fields:0 (expr_to_fn_body locals e1);
+        case_arm ~tag:(tagof ctor_tag_map "false") ~num_fields:0 (expr_to_fn_body locals e2)
       ])
   | EIfe _ -> failwith "expr_to_fn_body failed: if condition is not a variable"
   | EAnno (inner, _, _) -> expr_to_fn_body locals inner
@@ -173,14 +182,15 @@ and expr_to_fn_body globals locals (e : _ expr) : Rc.fn_body =
       let x = Utilities.new_var () in
       FnLet (x, expr_to_rexpr locals expr, FnRet (Rc.Var x))
 
-let to_rc_intermediate_representation (builtins : Rc.parameter_ownership) (p : _ program) : Refcount.program =
+let to_rc_intermediate_representation (ctor_tag_map : int StringMap.t) (builtins : Rc.parameter_ownership) (p : _ program) : Refcount.program =
   let globals : globals_env =
     let mapper = function
-      | TopLet (name, EFun (params, _, _), _) -> (fst name, Some (List.length params))
-      | TopLet (name, EAnno (EFun (params, _, _), _, _), _) -> (fst name, Some (List.length params))
-      | TopLet (name, _, _) -> (fst name, None)
+      | TopTypeDef _ -> None
+      | TopLet (name, EFun (params, _, _), _) -> Some (fst name, Some (List.length params))
+      | TopLet (name, EAnno (EFun (params, _, _), _, _), _) -> Some (fst name, Some (List.length params))
+      | TopLet (name, _, _) -> Some (fst name, None)
     in
-    let toplevel_arity = M.of_list (List.map mapper p) in
+    let toplevel_arity = M.of_list (List.filter_map mapper p) in
     let builtins_arity =
       builtins
       |> Collections.StringMap.to_list
@@ -191,16 +201,19 @@ let to_rc_intermediate_representation (builtins : Rc.parameter_ownership) (p : _
   in
   let to_fun names body =
     let params = List.map fst names in
-    Rc.Fun (params, expr_to_fn_body globals (LocalsEnv.of_list params) body)
+    Rc.Fun (params, expr_to_fn_body ctor_tag_map globals (LocalsEnv.of_list params) body)
   in
   let functions, globals =
     List.fold_right
-      (fun (TopLet (name, rhs, _)) (funcs, globs) ->
-        match rhs with
-        | EFun (names, body, _) | EAnno (EFun (names, body, _), _, _) ->
-            ((fst name, to_fun names body) :: funcs, globs)
-        | _ ->
-            (funcs, (fst name, expr_to_fn_body globals LocalsEnv.empty rhs) :: globs))
+      (fun te (funcs, globs) ->
+        match te with
+        | TopTypeDef _ -> (funcs, globs)
+        | TopLet (name, rhs, _) ->
+          match rhs with
+          | EFun (names, body, _) | EAnno (EFun (names, body, _), _, _) ->
+              ((fst name, to_fun names body) :: funcs, globs)
+          | _ ->
+              (funcs, (fst name, expr_to_fn_body ctor_tag_map globals LocalsEnv.empty rhs) :: globs))
       p
       ([], [])
   in

--- a/src/lib/transforms/remove_dup_names.ml
+++ b/src/lib/transforms/remove_dup_names.ml
@@ -2,7 +2,10 @@ open! Ast
 open Collections
 
 let rec subst_program (p: _ program) = 
-  List.map (fun (TopLet(x, rhs, ann)) -> TopLet(x, subst StringMap.empty rhs, ann)) p
+  p 
+  |> List.map (function 
+    | TopTypeDef _ as e -> e
+    | TopLet(x, rhs, ann) -> TopLet(x, subst StringMap.empty rhs, ann))
 
 and  subst (replacement_of : string StringMap.t) (e : 's expr) : 's expr =
   match e with

--- a/src/lib/transforms/simple_patterns.ml
+++ b/src/lib/transforms/simple_patterns.ml
@@ -69,8 +69,10 @@ let rec sink_until_first_use name proj ann e =
   | _ -> e
 
 let rec transform_patterns (p: 's Ast.program) = 
-  List.map (fun (TopLet (name, expr, ann)) -> TopLet (name, compile_match expr, ann)) p
-  
+  p |> List.map (function
+    | TopTypeDef _ as e -> e
+    | (TopLet (name, expr, ann)) -> TopLet (name, compile_match expr, ann))
+    
 and compile_simple_pattern scrutinee case_body = function
   | PWildcard _ ->
     Some (case_body ())

--- a/src/lib/transforms/typed_lowering.ml
+++ b/src/lib/transforms/typed_lowering.ml
@@ -14,6 +14,9 @@ let rec lower_program (p : typed program) : parsed program =
   List.map lower_top_expr p
 
 and lower_top_expr = function
+  | TopTypeDef (name, params, ctors, ann) ->
+    let ctors' = List.map (fun (ctor_name, arg_types, ctor_ann) -> (parsed_name ctor_name, arg_types, parsed_ann ctor_ann)) ctors in
+    TopTypeDef (parsed_name name, List.map parsed_name params, ctors', parsed_ann ann)
   | TopLet (name, expr, ann) -> TopLet (parsed_name name, lower_expr expr, parsed_ann ann)
 
 and lower_expr (e : typed expr) : parsed expr =

--- a/src/lib/transforms/typed_lowering.ml
+++ b/src/lib/transforms/typed_lowering.ml
@@ -41,7 +41,7 @@ and lower_expr (e : typed expr) : parsed expr =
     let lowered_e1 = lower_expr e1 in
     let lowered_e2 = lower_expr e2 in
     (match ann_get_type ann with
-    | TList _ ->
+    | TApp (TName "List", _) ->
       ECtor (("Cons", parsed_ann ann), [lowered_e1; lowered_e2], parsed_ann ann)
     | _ ->
       EBinary (SigCons, lowered_e1, lowered_e2, parsed_ann ann))

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -21,6 +21,10 @@ type typedefinition_env = {
   constructors: constructor_defintion StringMap.t; (* name -> constructor, a short cut*)
 }
 
+module TypeDefinitionEnv = struct
+  let to_ctor_mappings t = StringMap.map (fun (c : constructor_defintion) -> c.tag) t.constructors
+end
+
 type unification_env = typ IntMap.t (* id -> typ - union find *)
 
 type typing_state = {
@@ -360,3 +364,13 @@ let get_constructor_signature ann ctor_name : (typ list * typ) t =
       let* arg_types = List.map (fun t -> apply_subst ~subst_map:(Some subst_map) t) ctor_def.arg_types |> collect in
       let result_typ = TApp (TName ctor_def.result_typ, List.map snd type_params) in
       return (arg_types, result_typ)
+
+let has_type_definition type_name : bool t =
+  let open Operators in
+  let* typ_def_env = get_state |> map (fun s -> s.typedefinitions) in
+  return (StringMap.mem type_name typ_def_env.types)
+
+let has_ctor_definition ctor_name : bool t =
+  let open Operators in
+  let* typ_def_env = get_state |> map (fun s -> s.typedefinitions) in
+  return (StringMap.mem ctor_name typ_def_env.constructors)

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -6,8 +6,20 @@ type typing_error = Typing_error of Location.t * string
 type scheme = Forall of string list * typ
 type scheme_env = scheme StringMap.t
 
-type typedefinition = typ list
-type typedefinition_env = typedefinition StringMap.t
+type constructor_defintion = {
+  name: string;
+  arg_types: typ list;
+  result_typ: string;
+  tag: int;
+}
+type typedefinition = { 
+  constructors: constructor_defintion list;
+  type_params: string list;
+}
+type typedefinition_env = {
+  types: typedefinition StringMap.t;
+  constructors: constructor_defintion StringMap.t; (* name -> constructor, a short cut*)
+}
 
 type unification_env = typ IntMap.t (* id -> typ - union find *)
 
@@ -24,7 +36,7 @@ let empty_env = {
   errors = [];
   global = StringMap.empty;
   local = StringMap.empty;
-  typedefinitions = StringMap.empty;
+  typedefinitions = { types = StringMap.empty; constructors = StringMap.empty };
   unification_env = IntMap.empty;
   tvar_counter = 0;
 }
@@ -82,6 +94,10 @@ let add_global name scheme : unit t =
   modify_state (fun env -> 
     { env with global = StringMap.add name scheme env.global })
 
+let add_globals names_and_schemes : unit t = 
+  modify_state (fun env -> 
+    { env with global = StringMap.add_seq (List.to_seq names_and_schemes) env.global })
+
 let with_local_scope action : 'a t = 
   let open Operators in
   let* original_local = get_state |> map (fun s -> s.local) in
@@ -96,6 +112,46 @@ let with_local name scheme m =
   let open Operators in
   with_local_scope (let* () = add_local name scheme in m)
 
+let add_type_def name tparams : unit t =
+  let open Operators in
+  let* typ_def_env = get_state |> map (fun s -> s.typedefinitions) in
+  let typ_def = {constructors = []; type_params = tparams} in
+  let typ_def_env' = { typ_def_env with types = StringMap.add name typ_def typ_def_env.types } in
+  modify_state (fun s -> { s with typedefinitions = typ_def_env' })
+  
+let add_constructor_of type_name ctor_name arg_types : unit t =
+  let open Operators in
+  let* typ_def_env = get_state |> map (fun s -> s.typedefinitions) in
+  let* typ_def_env' = 
+    match StringMap.find_opt type_name typ_def_env.types with
+    | None -> failwith "Compiler error - attempting to add a constructor for a type that doesn't exist"
+    | Some typ_def -> 
+      let ctor_def = { name = ctor_name; arg_types; result_typ = type_name; tag = List.length typ_def.constructors } in
+      let updated_typ_def = { typ_def with constructors = ctor_def :: typ_def.constructors } in
+      let types = StringMap.add type_name updated_typ_def typ_def_env.types in
+      let constructors = StringMap.add ctor_name ctor_def typ_def_env.constructors in
+      return { types; constructors }
+  in
+  modify_state (fun s -> { s with typedefinitions = typ_def_env' })
+
+let prepare_with builtin_vars builtin_types action =
+  let open Operators in
+  (* print builtin_vars *)
+  let* _ = let* vars = collect builtin_vars in add_globals vars in
+  let* _ = 
+    builtin_types
+    |> List.fold_left (fun acc (type_name, type_params, ctors) -> 
+        let* _ = acc in
+        List.fold_left (fun acc (name, arg_types) -> 
+          let* _ = acc in 
+          add_constructor_of type_name name arg_types) 
+        (add_type_def type_name type_params) ctors
+      )
+    (return ())
+  in
+  let* action_result = action in
+  return action_result
+  
 (*  |-----------------------|
     |     UNIFICATION       |
     |-----------------------| *)
@@ -105,8 +161,9 @@ let rec occurs_in (tyvar_id: int) (t: typ) : bool =
   | TVar id -> tyvar_id = id
   | TError -> false
   | TUnit | TInt | TBool | TString | TName _ | TParam _-> false
-  | TSignal t | TLater t | TDelay t | TOption t | TList t | TChan t-> occurs_in tyvar_id t
-  | TSync (t1, t2) | TTuple (t1, t2) -> occurs_in tyvar_id t1 || occurs_in tyvar_id t2
+  | TSignal t | TLater t | TDelay t  | TChan t-> occurs_in tyvar_id t
+  | TTuple (t1, t2) -> occurs_in tyvar_id t1 || occurs_in tyvar_id t2
+  | TApp (t, ts) -> occurs_in tyvar_id t || List.exists (occurs_in tyvar_id) ts
   | TFun (Cons1(front, rest), t2) ->
     occurs_in tyvar_id front || List.exists (occurs_in tyvar_id) rest || occurs_in tyvar_id t2
 
@@ -127,11 +184,17 @@ let rec unify ann (t1: typ) (t2: typ) : unit t =
   | TName n1, TName n2 when n1 = n2 -> return ()
   | TParam p1, TParam p2 when p1 = p2 -> return ()
   | TSignal t1, TSignal t2 | TLater t1, TLater t2 | TDelay t1, TDelay t2 
-  | TChan t1, TChan t2 | TOption t1, TOption t2 | TList t1, TList t2 -> 
+  | TChan t1, TChan t2 -> 
     unify ann t1 t2
-  | TSync (t1a, t1b), TSync (t2a, t2b) | TTuple (t1a, t1b), TTuple (t2a, t2b) ->
+  | TTuple (t1a, t1b), TTuple (t2a, t2b) ->
     let* () = unify ann t1a t2a in
     unify ann t1b t2b
+  | TApp (t1, ts1), TApp (t2, ts2) ->
+    if List.length ts1 <> List.length ts2
+    then report_error ann (Format.asprintf "Type mismatch: cannot unify '%a' with '%a' because they have different number of type arguments" Ast.pp_typ t1 Ast.pp_typ t2)
+    else 
+      let* () = unify ann t1 t2 in
+      List.fold_left2 (fun acc t1 t2 -> let* _ = acc in unify ann t1 t2) (return ()) ts1 ts2
   | TFun (ts1, rt1), TFun (ts2, rt2) ->
     if List1.length ts1 <> List1.length ts2
     then
@@ -189,6 +252,10 @@ let rec apply_subst ?(subst_map = None) (t: typ) : typ t =
     | Some t' -> return t'
     | None -> return t)
   | TParam _ -> return t
+  | TApp (t, ts) -> 
+    let* t = apply_subst t in
+    let* ts = collect (List.map apply_subst ts) in
+    return (TApp (t, ts))
   | TSignal t -> 
     let* t = apply_subst t in
     return (TSignal t)
@@ -198,20 +265,10 @@ let rec apply_subst ?(subst_map = None) (t: typ) : typ t =
   | TDelay t -> 
     let* t = apply_subst t in
     return (TDelay t)
-  | TSync (t1, t2) -> 
-    let* t1 = apply_subst t1 in
-    let* t2 = apply_subst t2 in
-    return (TSync (t1,t2))
   | TTuple (t1, t2) -> 
     let* t1 = apply_subst t1 in
     let* t2 = apply_subst t2 in
     return (TTuple (t1,t2))
-  | TOption t -> 
-    let* t = apply_subst t in
-    return (TOption t)
-  | TList t ->
-    let* t = apply_subst t in
-    return (TList t)
   | TChan t -> 
     let* t = apply_subst t in
     return (TChan t)
@@ -261,16 +318,16 @@ let generalize_type_vars ?(id_to_name = ref IntMap.empty) typ : typ t =
     match typ with
     | TError -> return TError
     | TUnit | TInt | TBool | TString | TName _ | TParam _ -> return typ
+    | TApp (t, ts) -> 
+      let* t = go t in
+      let* ts = collect (List.map go ts) in
+      return (TApp (t, ts))
     | TSignal t -> let* t = go t in return (TSignal t)
     | TLater t  -> let* t = go t in return (TLater t)
     | TDelay t  -> let* t = go t in return (TDelay t)
-    | TOption t -> let* t = go t in return (TOption t)
-    | TList t -> let* t = go t in return (TList t)
     | TChan t   -> let* t = go t in return (TChan t)
     | TTuple (t1, t2) ->
       let* t1 = go t1 in let* t2 = go t2 in return (TTuple (t1, t2))
-    | TSync (t1, t2) ->
-      let* t1 = go t1 in let* t2 = go t2 in return (TSync (t1, t2))
     | TFun (Cons1(front, rest), ret) ->
       let* params = collect (List.map go (front :: rest)) in
       let* ret = go ret in
@@ -286,3 +343,20 @@ let generalize_type_vars ?(id_to_name = ref IntMap.empty) typ : typ t =
   in
   let* typ = apply_subst typ in
   go typ
+
+let get_constructor_signature ann ctor_name : (typ list * typ) t =
+  let open Operators in
+  let* typ_def_env = get_state |> map (fun s -> s.typedefinitions) in
+  match StringMap.find_opt ctor_name typ_def_env.constructors with
+  | None -> 
+    report_error ann (Format.asprintf "Unknown constructor: '%s'" ctor_name) 
+    |> map (fun () -> ([], TError))
+  | Some ctor_def -> 
+    match StringMap.find_opt ctor_def.result_typ typ_def_env.types with
+    | None -> failwith (Printf.sprintf "Compiler error - constructor '%s' refers to a type '%s' that doesn't exist" ctor_name ctor_def.result_typ)
+    | Some type_def ->
+      let* type_params = collect (List.map (fun v -> let* t = fresh_type_var () in return (v,t)) type_def.type_params) in
+      let subst_map = StringMap.of_list type_params in
+      let* arg_types = List.map (fun t -> apply_subst ~subst_map:(Some subst_map) t) ctor_def.arg_types |> collect in
+      let result_typ = TApp (TName ctor_def.result_typ, List.map snd type_params) in
+      return (arg_types, result_typ)

--- a/src/lib/typecheck.ml
+++ b/src/lib/typecheck.ml
@@ -180,24 +180,7 @@ let rec typecheck : type stage. stage program -> typing_result = fun p ->
     let* typ_free = free_type_vars_typ typ in
     return (name, forall (StringSet.to_list typ_free) typ)) Rizzo_builtins.builtins
   in
-  let builtin_types = 
-    [ ("Option", ["'a"], [
-        ("Just", [TParam "'a"]);
-        ("Nothing", [])
-      ])
-    ; ("List", ["'a"], [
-        ("Nil", []);
-        ("Cons", [TParam "'a"; TApp (TName "List", [TParam "'a"])])
-      ])
-    ; ("Sync", ["'a"; "'b"], [
-        ("Left", [TParam "'a"]);
-        ("Right", [TParam "'b"]);
-        ("Both", [TParam "'a"; TParam "'b"])
-      ])
-    ]
-  in
-
-  let typed_program, env = Type_env.run @@ Type_env.prepare_with builtins builtin_types (typecheck_program p) in
+  let typed_program, env = Type_env.run @@ Type_env.prepare_with builtins Rizzo_builtins.builtin_types (typecheck_program p) in
   let errors = List.map (function | Type_env.Typing_error (loc, err) -> (loc, err)) env.errors in
   { typed_program;
     type_errors = errors;
@@ -251,15 +234,22 @@ and probe_string_case_on_unresolved_scrutinee
   return (List.length probe_state.errors = base_error_count)
 
 and typecheck_program : type stage. stage program -> typed program Type_env.t = fun p -> 
-  let* checked_program = List.fold_left (fun acc (TopLet (name, e, ann)) -> 
+  let* checked_program = List.fold_left (fun acc te -> 
     let* acc = acc in
-    let name_text = fst name in
+    let* te = typecheck_top_expr te in
+    return (te :: acc)
+  ) (return []) p in
+  let* () = Type_env.flatten_unification_env in
+  normalize_typed_program (List.rev checked_program)
+
+and typecheck_top_expr : type stage. stage top_expr -> typed top_expr Type_env.t = function
+  | TopLet ((name, name_ann), e, ann) ->
     let* te = match e with
     | EFun (params, _, _) | EAnno (EFun (params, _, _), _, _)-> 
       let* param_types = Type_env.collect (List.map (fun _ -> Type_env.fresh_type_var ()) params) in
       let* ret_type = Type_env.fresh_type_var () in
       let  t = TFun (Cons1(List.hd param_types, List.tl param_types), ret_type) in
-      let* typed_e = Type_env.with_locals [name_text, mono t] (infer e) in
+      let* typed_e = Type_env.with_locals [name, mono t] (infer e) in
       let* inferred_t = get_typ typed_e in
       let* _ = Type_env.expected_equal ann inferred_t t in
       return typed_e
@@ -268,13 +258,41 @@ and typecheck_program : type stage. stage program -> typed program Type_env.t = 
     let* t = get_typ te in
     let* generalized_type = generalize t in
     let* t = Type_env.generalize_type_vars t in
-    let* () = Type_env.add_global name_text generalized_type in
-    let typed_name = (name_text, Ann_typed (get_location (snd name), t)) in
+    let* () = Type_env.add_global name generalized_type in
+    let typed_name = (name, Ann_typed (get_location name_ann, t)) in
     let toplet_expr = TopLet (typed_name, te, Ann_typed (get_location ann, t)) in
-    return (toplet_expr :: acc)
-  ) (return []) p in
-  let* () = Type_env.flatten_unification_env in
-  normalize_typed_program (List.rev checked_program)
+    return toplet_expr
+  | TopTypeDef ((tname, tname_ann), tparams, ctors, ann) -> 
+    (* I took the easy way out - any name clash is an error *)
+    let* already_exists = Type_env.has_type_definition tname in
+    let tname = if already_exists then Utilities.new_name tname else tname in
+    let* _ = Type_env.add_type_def tname (List.map fst tparams) in
+    let defined_type_params = StringSet.of_list (List.map fst tparams) in
+    let* _ = 
+      let mapper ((ctor_name, _), ctor_args, ctor_ann : stage ctor_def) =
+        (* duplicate constructors are just overwritten - so always is the latest - there is probably a better way *) 
+        let* ctor_args_free = Type_env.collect (List.map free_type_vars_typ ctor_args) in
+        let ctor_args_free = List.fold_left StringSet.union StringSet.empty ctor_args_free in
+        let* ctor_args = 
+          if not (StringSet.subset ctor_args_free defined_type_params) then
+            let guilty = StringSet.diff ctor_args_free defined_type_params |> StringSet.elements in
+            let err_msg = Format.asprintf "The following variables were unbound in definition of '%s': [%s]" tname (String.concat ", " guilty) in
+            let* _ = error ctor_ann err_msg in
+            return (List.map (fun _ -> TError) ctor_args)
+          else return ctor_args
+        in 
+        Type_env.add_constructor_of tname ctor_name ctor_args
+      in
+      Type_env.collect (List.map mapper ctors) in
+    let tparams' = List.map (fun (param_name, param_ann) -> (param_name, Ann_typed (get_location param_ann, TParam param_name))) tparams in
+    let ctors' =
+      List.map
+        (fun ((ctor_name, ctor_name_ann), ctor_args, ctor_ann) ->
+          ((ctor_name, Ann_typed (get_location ctor_name_ann, TName tname)), ctor_args, Ann_typed (get_location ctor_ann, TUnit)))
+        ctors
+    in
+    let res = TopTypeDef ((tname, Ann_typed (get_location tname_ann, TName tname)), tparams', ctors', Ann_typed (get_location ann, TUnit)) in
+    return res
 
 (** Infers the type of an expr*)
 and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
@@ -861,6 +879,7 @@ and normalize_typed_top_expr id_to_name : typed top_expr -> typed top_expr Type_
     let* expr = normalize_typed_expr id_to_name expr in
     let* ann = normalize_typed_ann id_to_name ann in
     return (TopLet (name, expr, ann))
+  | TopTypeDef _ as e -> return e
 
 and normalize_typed_program (program : typed program) : typed program Type_env.t =
   let id_to_name = ref IntMap.empty in

--- a/src/lib/typecheck.ml
+++ b/src/lib/typecheck.ml
@@ -412,7 +412,7 @@ and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
     let param_names = List.map2 (fun (p, pann) pt -> (p, Ann_typed(get_location pann, pt))) param_names param_types in
     return (EFun (param_names, typed_body, Ann_typed(get_location ann, fun_type)))
   | ECtor ((ctor_name, ctor_name_ann), args, ann) ->
-    let* arg_types, ctor_type = get_constructor_signature ctor_name ann in
+    let* arg_types, ctor_type = Type_env.get_constructor_signature ann ctor_name in
     let* inferred_args = Type_env.collect (List.map infer args) in
     let* inferred_arg_types = Type_env.collect (List.map get_typ inferred_args) in
     let* _ = 
@@ -542,15 +542,6 @@ and infer_const_type : type stage. stage ann -> const -> typ Type_env.t =
   | CNever -> 
     let* _ = error ann "Never cannot be inferred (yet) - consider annotating (never : Later T)" in
     return TError
-
-and get_constructor_signature : type stage. string -> stage ann -> (typ list * typ) Type_env.t =
-  fun ctor_name ann ->
-    let* res = Type_env.get_constructor_signature ann ctor_name in
-    match snd res with
-    | TError -> 
-      let* _ = error ann (Format.asprintf "Unknown constructor '%s' in pattern" ctor_name) in
-      return res
-    | _ -> return res
 
 and check_pattern : type stage. stage pattern -> typ -> (typed pattern * (string * scheme) list) Type_env.t =
   fun pattern expected_type ->

--- a/src/lib/typecheck.ml
+++ b/src/lib/typecheck.ml
@@ -166,10 +166,15 @@ and free_type_vars_env : unit -> StringSet.t Type_env.t = fun () ->
   let* local_free = free_type_vars_env_scheme env.local in
   return (StringSet.union global_free local_free)
 
-(*
-* Typechecks a program, returns a typed program and a boolean indicating whether there were any type errors (TODO: this is a bit of a hack - we should probably return the errors instead of printing them and returning a bool)
-*)
-let rec typecheck : type stage. stage program -> typed program * ((Location.t * string) list) = fun p -> 
+
+type typing_result = {
+  typed_program: typed program;
+  type_definitions: Type_env.typedefinition_env;
+  type_errors: (Location.t * string) list;
+}
+
+(** Typechecks a program, returns a typed program alongside type definitions and any reported errors *)
+let rec typecheck : type stage. stage program -> typing_result = fun p -> 
   (* decsribes the computations needed to arrive at the builtin schemes *)
   let builtins = List.map (fun ({name; typ; _}:Rizzo_builtins.builtin_info) -> 
     let* typ_free = free_type_vars_typ typ in
@@ -192,9 +197,11 @@ let rec typecheck : type stage. stage program -> typed program * ((Location.t * 
     ]
   in
 
-  let checked_program, env = Type_env.run @@ Type_env.prepare_with builtins builtin_types (typecheck_program p) in
+  let typed_program, env = Type_env.run @@ Type_env.prepare_with builtins builtin_types (typecheck_program p) in
   let errors = List.map (function | Type_env.Typing_error (loc, err) -> (loc, err)) env.errors in
-  (checked_program, errors)
+  { typed_program;
+    type_errors = errors;
+    type_definitions = env.typedefinitions; }
 
 and run_type_env_from_state : 'a. Type_env.typing_state -> 'a Type_env.t -> 'a * Type_env.typing_state =
   fun state m ->

--- a/src/lib/typecheck.ml
+++ b/src/lib/typecheck.ml
@@ -57,20 +57,18 @@ let rec generalize : typ -> scheme Type_env.t = fun t ->
       if IntSet.mem id generalized_tvars
       then return (TParam (fresh_param_name id))
       else return (TVar id)
+    | TApp (t, ts) ->
+      let* t = replace_generalized_tvars t in
+      let* ts = Type_env.collect (List.map replace_generalized_tvars ts) in
+      return (TApp (t, ts))
     | TSignal t -> let* t = replace_generalized_tvars t in return (TSignal t)
     | TLater t -> let* t = replace_generalized_tvars t in return (TLater t)
     | TDelay t -> let* t = replace_generalized_tvars t in return (TDelay t)
-    | TOption t -> let* t = replace_generalized_tvars t in return (TOption t)
-    | TList t -> let* t = replace_generalized_tvars t in return (TList t)
     | TChan t -> let* t = replace_generalized_tvars t in return (TChan t)
     | TTuple (t1, t2) ->
       let* t1 = replace_generalized_tvars t1 in
       let* t2 = replace_generalized_tvars t2 in
       return (TTuple (t1, t2))
-    | TSync (t1, t2) ->
-      let* t1 = replace_generalized_tvars t1 in
-      let* t2 = replace_generalized_tvars t2 in
-      return (TSync (t1, t2))
     | TFun (Cons1 (front, rest), ret) ->
       let* params = Type_env.collect (List.map replace_generalized_tvars (front :: rest)) in
       let* ret = replace_generalized_tvars ret in
@@ -90,12 +88,16 @@ and free_tvar_ids_typ : typ -> IntSet.t Type_env.t = fun t ->
   match t with
   | TError -> return IntSet.empty
   | TVar id -> return (IntSet.singleton id)
-  | TTuple (t1, t2) | TSync (t1, t2) ->
+  | TTuple (t1, t2) ->
     let* t1_free = free_tvar_ids_typ t1 in
     let* t2_free = free_tvar_ids_typ t2 in
     return (IntSet.union t1_free t2_free)
-  | TSignal t | TDelay t | TLater t | TOption t | TList t | TChan t -> free_tvar_ids_typ t
+  | TSignal t | TDelay t | TLater t | TChan t -> free_tvar_ids_typ t
   | TUnit | TInt | TBool | TString | TName _ | TParam _ -> return IntSet.empty
+  | TApp (t, ts) ->
+    let* t_free = free_tvar_ids_typ t in
+    let* ts_free = Type_env.collect (List.map free_tvar_ids_typ ts) in
+    return (List.fold_left IntSet.union t_free ts_free)
   | TFun (Cons1 (front, rest), ret_type) ->
     let* param_free =
       List.fold_left
@@ -127,12 +129,16 @@ and free_tvar_ids_env : unit -> IntSet.t Type_env.t = fun () ->
 and free_type_vars_typ : typ -> StringSet.t Type_env.t = function
   | TError -> return StringSet.empty
   | TVar _ -> return StringSet.empty
-  | TTuple (t1, t2) | TSync (t1, t2) -> 
+  | TTuple (t1, t2) -> 
     let* t1_free = free_type_vars_typ t1 in
     let* t2_free = free_type_vars_typ t2 in
     return (StringSet.union t1_free t2_free)
-  | TSignal t | TDelay t | TLater t | TOption t | TList t | TChan t -> free_type_vars_typ t
-  | TUnit | TInt | TBool | TString | TName _ -> return StringSet.empty
+  | TApp (t, ts) ->
+    let* t_free = free_type_vars_typ t in
+    let* ts_free = Type_env.collect (List.map free_type_vars_typ ts) in
+    return (List.fold_left StringSet.union t_free ts_free)
+  | TSignal t | TDelay t | TLater t | TChan t -> free_type_vars_typ t
+  | TUnit | TInt | TBool | TString  | TName _ -> return StringSet.empty
   | TParam v -> return (StringSet.singleton v)
   | TFun (Cons1(front, rest), ret_type) -> 
     let* param_free = List.fold_left (fun acc t -> 
@@ -164,12 +170,29 @@ and free_type_vars_env : unit -> StringSet.t Type_env.t = fun () ->
 * Typechecks a program, returns a typed program and a boolean indicating whether there were any type errors (TODO: this is a bit of a hack - we should probably return the errors instead of printing them and returning a bool)
 *)
 let rec typecheck : type stage. stage program -> typed program * ((Location.t * string) list) = fun p -> 
-  let builtins,_ = Type_env.run @@ Type_env.collect (List.map 
-    (fun ({name; typ; _}:Rizzo_builtins.builtin_info) -> 
-      let* typ_free = free_type_vars_typ typ in
-      return (name, forall (StringSet.to_list typ_free) typ)) 
-    Rizzo_builtins.builtins) in
-  let checked_program, env  = Type_env.run (typecheck_program p) ~builtins:(Some builtins) in
+  (* decsribes the computations needed to arrive at the builtin schemes *)
+  let builtins = List.map (fun ({name; typ; _}:Rizzo_builtins.builtin_info) -> 
+    let* typ_free = free_type_vars_typ typ in
+    return (name, forall (StringSet.to_list typ_free) typ)) Rizzo_builtins.builtins
+  in
+  let builtin_types = 
+    [ ("Option", ["'a"], [
+        ("Just", [TParam "'a"]);
+        ("Nothing", [])
+      ])
+    ; ("List", ["'a"], [
+        ("Nil", []);
+        ("Cons", [TParam "'a"; TApp (TName "List", [TParam "'a"])])
+      ])
+    ; ("Sync", ["'a"; "'b"], [
+        ("Left", [TParam "'a"]);
+        ("Right", [TParam "'b"]);
+        ("Both", [TParam "'a"; TParam "'b"])
+      ])
+    ]
+  in
+
+  let checked_program, env = Type_env.run @@ Type_env.prepare_with builtins builtin_types (typecheck_program p) in
   let errors = List.map (function | Type_env.Typing_error (loc, err) -> (loc, err)) env.errors in
   (checked_program, errors)
 
@@ -180,7 +203,7 @@ and run_type_env_from_state : 'a. Type_env.typing_state -> 'a Type_env.t -> 'a *
 
 and tail_expr_has_known_list_shape : type stage. stage expr -> bool Type_env.t = function
   | ECtor (("Nil", _), _, _) | ECtor (("Cons", _), _, _) -> return true
-  | EAnno (_, TList _, _) -> return true
+  | EAnno (_, TApp (TName "List", _), _) -> return true
   | tail_expr ->
     let* state = Type_env.get_state in
     let probe : bool Type_env.t =
@@ -188,7 +211,7 @@ and tail_expr_has_known_list_shape : type stage. stage expr -> bool Type_env.t =
       let* tail_t = get_typ inferred_tail in
       let* tail_t = Type_env.apply_subst tail_t in
       match tail_t with
-      | TList _ -> return true
+      | TApp (TName "List", _) -> return true
       | _ -> return false
     in
     let result, _ = run_type_env_from_state state probe in
@@ -278,8 +301,7 @@ and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
     let* env = Type_env.get_state in
     let* var_type = 
       match StringMap.find_opt name env.local with
-      | Some scheme ->
-        Type_env.instantiate_scheme scheme
+      | Some scheme -> Type_env.instantiate_scheme scheme
       | None -> (
         match StringMap.find_opt name env.global with
         | Some scheme -> Type_env.instantiate_scheme scheme
@@ -364,9 +386,8 @@ and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
     let fun_type = TFun (Cons1(List.hd param_types, List.tl param_types), body_type) in
     let param_names = List.map2 (fun (p, pann) pt -> (p, Ann_typed(get_location pann, pt))) param_names param_types in
     return (EFun (param_names, typed_body, Ann_typed(get_location ann, fun_type)))
-  | ECtor ((typ_name, typ_name_ann), args, ann) ->
-    (* TODO: proper handling here - [get_constructor_signature] returns an error message mentioning patterns! *)
-    let* arg_types, ctor_type = get_constructor_signature typ_name typ_name_ann in
+  | ECtor ((ctor_name, ctor_name_ann), args, ann) ->
+    let* arg_types, ctor_type = get_constructor_signature ctor_name ann in
     let* inferred_args = Type_env.collect (List.map infer args) in
     let* inferred_arg_types = Type_env.collect (List.map get_typ inferred_args) in
     let* _ = 
@@ -375,11 +396,11 @@ and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
       if n_args = n_inferred
       then Type_env.collect (List.map2 (Type_env.expected_equal ann) arg_types inferred_arg_types)
       else
-        let* _ = error ann (Format.asprintf "Constructor '%s' expects %d argument(s), but got %d" typ_name n_args n_inferred) in
+        let* _ = error ann (Format.asprintf "Constructor '%s' expects %d argument(s), but got %d" ctor_name n_args n_inferred) in
         return []
     in
     let* ctor_type = Type_env.apply_subst ctor_type in
-    let name = (typ_name, Ann_typed (get_location typ_name_ann, ctor_type)) in
+    let name = (ctor_name, Ann_typed (get_location ctor_name_ann, ctor_type)) in
     return (ECtor (name, inferred_args, Ann_typed (get_location ann, ctor_type)))
 
 (** Checks a type against an expected type *)
@@ -465,10 +486,11 @@ and check : type stage. stage expr -> typ -> typed expr Type_env.t = fun e expec
     return (ECase (tscrutinee, typed_branches, Ann_typed (get_location ann, result_type)))
   | EBinary (SigCons, e1, e2, ann) ->
     (match expected with
-    | TList elem_t ->
+    | TApp (TName "List", [elem_t]) ->
       let* typed_hd = check e1 elem_t in
-      let* typed_tl = check e2 (TList elem_t) in
-      let* result_type = Type_env.apply_subst (TList elem_t) in
+      let lst_t = TApp (TName "List", [elem_t]) in
+      let* typed_tl = check e2 lst_t in
+      let* result_type = Type_env.apply_subst lst_t in
       return (EBinary (SigCons, typed_hd, typed_tl, Ann_typed (get_location ann, result_type)))
     | TSignal elem_t ->
       let* typed_hd = check e1 elem_t in
@@ -498,34 +520,12 @@ and infer_const_type : type stage. stage ann -> const -> typ Type_env.t =
 
 and get_constructor_signature : type stage. string -> stage ann -> (typ list * typ) Type_env.t =
   fun ctor_name ann ->
-  match ctor_name with
-  | "Just" ->
-    let* a = Type_env.fresh_type_var () in
-    return ([a], TOption a)
-  | "Nothing" ->
-    let* a = Type_env.fresh_type_var () in
-    return ([], TOption a)
-  | "Nil" ->
-    let* a = Type_env.fresh_type_var () in
-    return ([], TList a)
-  | "Cons" ->
-    let* a = Type_env.fresh_type_var () in
-    return ([a; TList a], TList a)
-  | "Left" ->
-    let* a = Type_env.fresh_type_var () in
-    let* b = Type_env.fresh_type_var () in
-    return ([a], TSync (a, b))
-  | "Right" ->
-    let* a = Type_env.fresh_type_var () in
-    let* b = Type_env.fresh_type_var () in
-    return ([b], TSync (a, b))
-  | "Both" ->
-    let* a = Type_env.fresh_type_var () in
-    let* b = Type_env.fresh_type_var () in
-    return ([a; b], TSync (a, b))
-  | _ ->
-    let* _ = error ann (Format.asprintf "Unknown constructor pattern '%s'" ctor_name) in
-    return ([], TError)
+    let* res = Type_env.get_constructor_signature ann ctor_name in
+    match snd res with
+    | TError -> 
+      let* _ = error ann (Format.asprintf "Unknown constructor '%s' in pattern" ctor_name) in
+      return res
+    | _ -> return res
 
 and check_pattern : type stage. stage pattern -> typ -> (typed pattern * (string * scheme) list) Type_env.t =
   fun pattern expected_type ->
@@ -567,13 +567,13 @@ and check_pattern : type stage. stage pattern -> typ -> (typed pattern * (string
       let tail_binding = (tail_name, mono TString) in
       let typed_tail = (tail_name, Ann_typed (get_location tail_ann, TString)) in
       return (PStringCons (typed_hd, typed_tail, Ann_typed (get_location ann, TString)), hd_bindings @ [tail_binding])
-    | TList a ->
+    | TApp (TName "List", [a]) ->
       let* a = Type_env.apply_subst a in
       let* typed_hd, hd_bindings = check_pattern hd_pattern a in
-      let tail_type = TList a in
+      let tail_type = TApp (TName "List", [a]) in
       let tail_binding = (tail_name, mono tail_type) in
       let typed_tail = PVar (tail_name, Ann_typed (get_location tail_ann, tail_type)) in
-      let pattern_type = TList a in
+      let pattern_type = TApp (TName "List", [a]) in
       let typed_ctor = ("Cons", Ann_typed (get_location ann, pattern_type)) in
       return (PCtor (typed_ctor, [typed_hd; typed_tail], Ann_typed (get_location ann, pattern_type)), hd_bindings @ [tail_binding])
     | _ ->
@@ -584,7 +584,7 @@ and check_pattern : type stage. stage pattern -> typ -> (typed pattern * (string
     let* _ = error ann "Internal error: string-cons pattern should not appear before typed lowering" in
     return (PWildcard (Ann_typed (get_location ann, TError)), [])
   | PCtor ((ctor_name, ctor_ann), args, ann) ->
-    let* param_types, ctor_result = get_constructor_signature ctor_name ctor_ann in
+    let* param_types, ctor_result = Type_env.get_constructor_signature ctor_ann ctor_name in
     let* _ = Type_env.expected_equal ann expected_type ctor_result in
     let expected_arity = List.length param_types in
     let actual_arity = List.length args in
@@ -622,8 +622,8 @@ and infer_binary : type stage. binary_op -> stage expr -> stage expr -> stage an
     let* t1 = get_typ te1 in
     let* prefers_list = tail_expr_has_known_list_shape e2 in
     if prefers_list then
-      let* te2 = check e2 (TList t1) in
-      let* result_t = Type_env.apply_subst (TList t1) in
+      let* te2 = check e2 (TApp (TName "List", [t1])) in
+      let* result_t = Type_env.apply_subst (TApp (TName "List", [t1])) in
       return (EBinary (SigCons, te1, te2, Ann_typed (get_location ann, result_t)))
     else
       let* te2 = check e2 (TLater (TSignal t1)) in
@@ -660,7 +660,7 @@ and infer_binary : type stage. binary_op -> stage expr -> stage expr -> stage an
     let* te2 = check e2 (TLater a2)in 
     let* a1 = Type_env.apply_subst a1 in
     let* a2 = Type_env.apply_subst a2 in
-    return (EBinary (BSync, te1, te2, Ann_typed (get_location ann, TLater (TSync (a1, a2))))) 
+    return (EBinary (BSync, te1, te2, Ann_typed (get_location ann, TLater (TApp (TName "Sync", [a1; a2]))))) 
   | BOStar ->
     let* a = Type_env.fresh_type_var () in
     let* b = Type_env.fresh_type_var () in
@@ -688,7 +688,7 @@ and infer_unary : type s. Ast.unary_op -> s expr -> s ann -> typed expr Type_env
     return (EUnary (UNot, te, Ann_typed (get_location ann, TBool)))
   | UWatch -> 
     let* fresh_t = Type_env.fresh_type_var () in
-    let* te = check e (TSignal (TOption (fresh_t))) in (* Signal (Option A) *)
+    let* te = check e (TSignal (TApp (TName "Option", [fresh_t]))) in (* Signal (Option A) *)
     let* t = Type_env.apply_subst fresh_t in
     return (EUnary (UWatch, te, Ann_typed (get_location ann, TLater t)))
   | UTail ->
@@ -706,8 +706,19 @@ and infer_unary : type s. Ast.unary_op -> s expr -> s ann -> typed expr Type_env
     let* t = get_typ te in
     match t with 
     | TError -> return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))) (* stop cascading errors *)
-    | TString | TUnit | TInt | TBool | TName _ | TParam _ | TVar _| TFun _ | TChan _ -> 
+    | TApp (TName "List", [t]) as lst_t->
+      (match i with
+      | 0 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, t)))
+      | 1 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, lst_t)))
+      | _ ->
+        let* _ = error ann "List has 2 projections: 0 for head and 1 for tail" in
+        return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))))
+    | TApp _ -> failwith "todo TAPP in infer unary"
+    | TString | TUnit | TInt | TBool | TParam _ | TVar _| TFun _ | TChan _ -> 
       let* _ = error ann (Format.asprintf "Cannot project from non-constructor '%a'" Ast.pp_typ t) in
+      return (EUnary (UProj i, te, Ann_typed (get_location ann, TError)))
+    | TName typ_name -> 
+      let* _ = error ann (Format.asprintf "Cannot project from type name '%s'" typ_name) in
       return (EUnary (UProj i, te, Ann_typed (get_location ann, TError)))
     | TLater _ -> 
       let* _ = error ann (Format.asprintf "Cannot project a LATER! '%a'" Ast.pp_typ t) in
@@ -722,19 +733,6 @@ and infer_unary : type s. Ast.unary_op -> s expr -> s ann -> typed expr Type_env
       | _ -> 
         let* _ = error ann "Signal only has 2 projections: 0 for head and 1 for tail" in
         return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))))
-    | TOption t -> 
-      (match i with
-      | 0 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, t))) 
-      | _ -> 
-        let* _ = error ann "Option has at most one projection" in
-        return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))))
-    | TList t ->
-      (match i with
-      | 0 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, t)))
-      | 1 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, TList t)))
-      | _ ->
-        let* _ = error ann "List has 2 projections: 0 for head and 1 for tail" in
-        return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))))
     | TTuple (t1, t2) -> 
       (match i with
       | 0 -> return (EUnary (UProj i, te, Ann_typed (get_location ann, t1))) 
@@ -742,9 +740,6 @@ and infer_unary : type s. Ast.unary_op -> s expr -> s ann -> typed expr Type_env
       | _ -> 
         let* _ = error ann "Tuple only has 2 projections: 0 for first and 1 for second" in
         return (EUnary (UProj i, te, Ann_typed (get_location ann, TError))))
-    | TSync _ -> 
-      let* _ = error ann "Cannot project a sync?" in
-      return (EUnary (UProj i, te, Ann_typed (get_location ann, TError)))
 and normalize_typed_ann : type stage. (string IntMap.t ref) -> stage ann -> stage ann Type_env.t =
   fun id_to_name -> function
   | Ann_typed (loc, typ) ->

--- a/src/runtime/builtins.h
+++ b/src/runtime/builtins.h
@@ -16,8 +16,8 @@ static inline rz_box_t rz_eq(rz_box_t a, rz_box_t b);
 
 enum
 {
-	RZ_TAG_LIST_NIL = 2,
-	RZ_TAG_LIST_CONS = 3,
+	RZ_TAG_LIST_NIL = 0,
+	RZ_TAG_LIST_CONS = 1,
 };
 
 static inline void rz_builtin_expect_arity(const char *name, size_t expected, size_t actual)

--- a/src/test/test_bool_ops.ml
+++ b/src/test/test_bool_ops.ml
@@ -4,7 +4,10 @@ open! Rizzoc.RefCount
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = typecheck parsed in
+  let typed, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "type errors" 0 (List.length errors);
   typed
 

--- a/src/test/test_bool_ops.ml
+++ b/src/test/test_bool_ops.ml
@@ -4,15 +4,12 @@ open! Rizzoc.RefCount
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
-    typed_program, type_errors
-  in
-  Alcotest.(check int) "type errors" 0 (List.length errors);
-  typed
+  let {typed_program; type_errors; type_definitions} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
+  Alcotest.(check int) "type errors" 0 (List.length type_errors);
+  typed_program, TypeCheck.type_definitions_to_ctor_mappings type_definitions
 
 let test_typecheck_not_operator () =
-  let typed =
+  let typed, _ =
     parse_and_typecheck
       ("let flipped = !true\n"
       ^ "let named = not false\n")
@@ -25,10 +22,10 @@ let test_typecheck_not_operator () =
   | _ -> Alcotest.fail "unexpected typed AST shape for not operator"
 
 let test_rc_lowering_maps_not_to_builtin () =
-  let typed = parse_and_typecheck "let flipped = !true\n" in
+  let typed, constructors = parse_and_typecheck "let flipped = !true\n" in
   let lowered = lower_typed_program typed in
   Utilities.new_name_reset ();
-  let actual = Transformations.ast_to_rc_ir Transformations.builtins lowered in
+  let actual = Transformations.ast_to_rc_ir constructors Transformations.builtins lowered in
   match actual with
   | RefProg
       { functions = [];

--- a/src/test/test_builtins.ml
+++ b/src/test/test_builtins.ml
@@ -5,7 +5,7 @@ open Ast_test_helpers
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
   let typed, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    let {typed_program; type_errors; _} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
     typed_program, type_errors
   in
   Alcotest.(check int) "type errors" 0 (List.length errors);

--- a/src/test/test_builtins.ml
+++ b/src/test/test_builtins.ml
@@ -4,7 +4,10 @@ open Ast_test_helpers
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = typecheck parsed in
+  let typed, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "type errors" 0 (List.length errors);
   typed
 

--- a/src/test/test_builtins.ml
+++ b/src/test/test_builtins.ml
@@ -21,10 +21,10 @@ let test_parse_int_has_expected_type () =
   | [TopLet (_, EApp (EVar ("parse_int", Ann_typed (_, builtin_t)), [_], Ann_typed (_, result_t)), _)] ->
       Alcotest.(check bool) "parse_int builtin type"
         true
-        (Ast.eq_typ builtin_t (TFun (Cons1 (TString, []), TOption TInt)));
+        (Ast.eq_typ builtin_t (TFun (Cons1 (TString, []), TApp (TName "Option", [TInt]))));
       Alcotest.(check bool) "parse_int return type"
         true
-        (Ast.eq_typ result_t (TOption TInt))
+        (Ast.eq_typ result_t (TApp (TName "Option", [TInt])))
   | _ -> Alcotest.fail "unexpected typed AST shape for parse_int builtin"
 
 let test_clock_has_expected_type () =
@@ -86,16 +86,17 @@ let test_list_constructors_and_projection_builtins_have_expected_types () =
       ^ "let first = list_head nums\n"
       ^ "let rest = list_tail nums\n")
   in
+  let open Ast.Factory in
   match typed with
-  | [ TopLet (_, EAnno (_, TList TInt, _), _);
+  | [ TopLet (_, EAnno (_, TApp (TName "List", [TInt]), _), _);
       TopLet (_, EBinary (SigCons, _, _, Ann_typed (_, nums_t)), _);
       TopLet (_, EApp (EVar ("list_head", Ann_typed (_, head_builtin_t)), [_], Ann_typed (_, first_t)), _);
       TopLet (_, EApp (EVar ("list_tail", Ann_typed (_, tail_builtin_t)), [_], Ann_typed (_, rest_t)), _) ] ->
-      Alcotest.(check bool) "cons infers list type" true (Ast.eq_typ nums_t (TList TInt));
-      Alcotest.(check bool) "list_head builtin type" true (Ast.eq_typ head_builtin_t (TFun (Cons1 (TList TInt, []), TInt)));
+      Alcotest.(check bool) "cons infers list type" true (Ast.eq_typ nums_t (typ_list TInt));
+      Alcotest.(check bool) "list_head builtin type" true (Ast.eq_typ head_builtin_t (TFun (Cons1 (typ_list TInt, []), TInt)));
       Alcotest.(check bool) "list_head result type" true (Ast.eq_typ first_t TInt);
-      Alcotest.(check bool) "list_tail builtin type" true (Ast.eq_typ tail_builtin_t (TFun (Cons1 (TList TInt, []), TList TInt)));
-      Alcotest.(check bool) "list_tail result type" true (Ast.eq_typ rest_t (TList TInt))
+      Alcotest.(check bool) "list_tail builtin type" true (Ast.eq_typ tail_builtin_t (TFun (Cons1 (typ_list TInt, []), typ_list TInt)));
+      Alcotest.(check bool) "list_tail result type" true (Ast.eq_typ rest_t (typ_list TInt))
   | _ -> Alcotest.fail "unexpected typed AST shape for list constructors and projection builtins"
 
 let test_list_supporting_builtins_have_expected_types () =
@@ -106,17 +107,18 @@ let test_list_supporting_builtins_have_expected_types () =
       ^ "let count = list_length [1, 2, 3]\n"
       ^ "let words = string_split \"a,b\" \",\"\n")
   in
+  let open Ast.Factory in
   match typed with
   | [ TopLet (_, _, _);
       TopLet (_, EApp (EVar ("list_is_empty", Ann_typed (_, empty_builtin_t)), [_], Ann_typed (_, empty_result_t)), _);
       TopLet (_, EApp (EVar ("list_length", Ann_typed (_, length_builtin_t)), [_], Ann_typed (_, length_result_t)), _);
       TopLet (_, EApp (EVar ("string_split", Ann_typed (_, split_builtin_t)), [_; _], Ann_typed (_, split_result_t)), _) ] ->
-      Alcotest.(check bool) "list_is_empty builtin type" true (Ast.eq_typ empty_builtin_t (TFun (Cons1 (TList TInt, []), TBool)));
+      Alcotest.(check bool) "list_is_empty builtin type" true (Ast.eq_typ empty_builtin_t (typ_fun1 (typ_list TInt) TBool));
       Alcotest.(check bool) "list_is_empty result type" true (Ast.eq_typ empty_result_t TBool);
-      Alcotest.(check bool) "list_length builtin type" true (Ast.eq_typ length_builtin_t (TFun (Cons1 (TList TInt, []), TInt)));
+      Alcotest.(check bool) "list_length builtin type" true (Ast.eq_typ length_builtin_t (typ_fun1 (typ_list TInt) TInt));
       Alcotest.(check bool) "list_length result type" true (Ast.eq_typ length_result_t TInt);
-      Alcotest.(check bool) "string_split builtin type" true (Ast.eq_typ split_builtin_t (TFun (Cons1 (TString, [TString]), TList TString)));
-      Alcotest.(check bool) "string_split result type" true (Ast.eq_typ split_result_t (TList TString))
+      Alcotest.(check bool) "string_split builtin type" true (Ast.eq_typ split_builtin_t (typ_fun [TString; TString] (typ_list TString)));
+      Alcotest.(check bool) "string_split result type" true (Ast.eq_typ split_result_t (typ_list TString))
   | _ -> Alcotest.fail "unexpected typed AST shape for list support builtins"
 
 let test_lower_typed_program_rewrites_list_cons_to_constructor () =

--- a/src/test/test_int_ops.ml
+++ b/src/test/test_int_ops.ml
@@ -4,15 +4,12 @@ open! Rizzoc.RefCount
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
-    typed_program, type_errors
-  in
-  Alcotest.(check int) "type errors" 0 (List.length errors);
-  typed
+  let {typed_program; type_errors; type_definitions} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
+  Alcotest.(check int) "type errors" 0 (List.length type_errors);
+  typed_program, TypeCheck.type_definitions_to_ctor_mappings type_definitions
 
 let test_typecheck_int_operators () =
-  let typed =
+  let typed, _ =
     parse_and_typecheck
       ("let diff = 9 - 4\n"
       ^ "let product = 3 * 2\n"
@@ -43,10 +40,10 @@ let test_typecheck_int_operators () =
   | _ -> Alcotest.fail "unexpected typed AST shape for int operators"
 
 let test_rc_lowering_maps_mod_to_builtin () =
-  let typed = parse_and_typecheck "let remainder = 5 % 2\n" in
+  let typed, constructors = parse_and_typecheck "let remainder = 5 % 2\n" in
   let lowered = lower_typed_program typed in
   Utilities.new_name_reset ();
-  let actual = Transformations.ast_to_rc_ir Transformations.builtins lowered in
+  let actual = Transformations.ast_to_rc_ir constructors Transformations.builtins lowered in
   match actual with
   | RefProg
       { functions = [];
@@ -56,14 +53,14 @@ let test_rc_lowering_maps_mod_to_builtin () =
   | _ -> Alcotest.fail "unexpected RC lowering shape for mod"
 
 let test_rc_lowering_maps_greater_ops_to_builtins () =
-  let typed =
+  let typed, constructors =
     parse_and_typecheck
       ("let bigger = 5 > 2\n"
       ^ "let at_least = 5 >= 2\n")
   in
   let lowered = lower_typed_program typed in
   Utilities.new_name_reset ();
-  let actual = Transformations.ast_to_rc_ir Transformations.builtins lowered in
+  let actual = Transformations.ast_to_rc_ir constructors Transformations.builtins lowered in
   match actual with
   | RefProg
       { functions = [];

--- a/src/test/test_int_ops.ml
+++ b/src/test/test_int_ops.ml
@@ -4,7 +4,10 @@ open! Rizzoc.RefCount
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = typecheck parsed in
+  let typed, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "type errors" 0 (List.length errors);
   typed
 

--- a/src/test/test_language_service.ml
+++ b/src/test/test_language_service.ml
@@ -570,6 +570,47 @@ let test_hover_and_completion_for_typed_top_level_function () =
   | None -> Alcotest.fail "expected annotated top-level function completion"
   | Some item -> Alcotest.(check int) "completion kind is function" 3 item.Language_service.kind
 
+let test_hover_on_top_type_definition_uses_definition_text () =
+  let text =
+    "type MyOption 'a =\n"
+    ^ "    | MNothing\n"
+    ^ "    | MJust('a)\n"
+    ^ "\n"
+    ^ "fun some x = MJust (x)\n"
+  in
+  match Language_service.hover_at_position
+          ~uri:"file:///test.rizz"
+          ~filename:None
+          ~text
+          ~position:{ Language_service.line = 0; character = 0 }
+  with
+  | None -> Alcotest.fail "expected hover for type definition"
+  | Some hover ->
+      Alcotest.(check bool)
+        "hover shows type definition text"
+        true
+        (contains_substring ~text:hover.Language_service.contents ~substring:"type MyOption 'a =");
+      Alcotest.(check bool)
+        "hover uses a syntax-highlighted code block"
+        true
+        (contains_substring ~text:hover.Language_service.contents ~substring:"```rizz");
+      Alcotest.(check bool)
+        "hover includes constructors"
+        true
+        (contains_substring ~text:hover.Language_service.contents ~substring:"MNothing");
+      Alcotest.(check bool)
+        "hover includes constructor args"
+        true
+        (contains_substring ~text:hover.Language_service.contents ~substring:"MJust('a)");
+      Alcotest.(check bool)
+        "hover omits expression block"
+        false
+        (contains_substring ~text:hover.Language_service.contents ~substring:"Expr:");
+      Alcotest.(check int)
+        "hover range starts at type keyword"
+        0
+        hover.Language_service.range.start_pos.character
+
 let test_hover_on_function_parameter_uses_name_range () =
   let text = "fun pair first second = first\n" in
   match Language_service.hover_at_position
@@ -748,6 +789,7 @@ let tests = [
    "completion includes builtins and constructors", `Quick, test_completions_include_builtins_and_constructors;
    "completion prefix filtering", `Quick, test_completions_filter_by_prefix;
    "hover and completion for typed top-level function", `Quick, test_hover_and_completion_for_typed_top_level_function;
+  "hover on type definition uses definition text", `Quick, test_hover_on_top_type_definition_uses_definition_text;
   "hover on function parameter uses name range", `Quick, test_hover_on_function_parameter_uses_name_range;
    "hover inside string literal uses full range", `Quick, test_hover_inside_string_literal_uses_full_range;
    "hover on local let binding uses name range", `Quick, test_hover_on_local_let_binding_uses_name_range;

--- a/src/test/test_map2.ml
+++ b/src/test/test_map2.ml
@@ -4,7 +4,7 @@ open Rizzoc.Ast
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
   let typed, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    let {typed_program; type_errors; _} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
     typed_program, type_errors
   in
   Alcotest.(check int) "type errors" 0 (List.length errors);

--- a/src/test/test_map2.ml
+++ b/src/test/test_map2.ml
@@ -3,7 +3,10 @@ open Rizzoc.Ast
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = typecheck parsed in
+  let typed, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "type errors" 0 (List.length errors);
   typed
 

--- a/src/test/test_map2.ml
+++ b/src/test/test_map2.ml
@@ -52,7 +52,7 @@ let rec find_typed_let_binding target (e : typed expr) : (typ * typ * typed expr
   | EAnno (e, _, _) -> find_typed_let_binding target e
 
 let is_sync_signal_to_signal = function
-  | TFun (Cons1 (TSync (TSignal _, TSignal _), []), TSignal _) -> true
+  | TFun (Cons1 (TApp (TName "Sync", [TSignal _; TSignal _]), []), TSignal _) -> true
   | _ -> false
 
 let is_signal = function

--- a/src/test/test_parser.ml
+++ b/src/test/test_parser.ml
@@ -133,6 +133,21 @@ let test_list_literals_and_patterns_parse () =
   in
   Alcotest.check program_testable "list literals and patterns parse" expected parsed
 
+let test_type_annotation_with_applied_tuple_type () =
+  let input =
+    "let xs : List Int * Option (List String) = value\n"
+  in
+  let parsed = Rizzoc.Parser.parse_string input in
+  match parsed with
+  | [ TopLet (_, EAnno (_, annotated_type, _), _) ] ->
+    let expected_type =
+      TTuple
+        (TApp (TName "List", [TInt]),
+         TApp (TName "Option", [TApp (TName "List", [TString])]))
+    in
+    Alcotest.(check bool) "annotation parses as expected" true (eq_typ annotated_type expected_type)
+  | _ -> Alcotest.fail "expected a single annotated top-level let"
+
 let parser_tests =
   [
     "parser accepts syntax", `Quick, test_parser_program;
@@ -143,4 +158,5 @@ let parser_tests =
     "effectful decorator", `Quick, test_effectful_decorator_marks_function;
     "constructor application with parenthesized let", `Quick, test_constructor_application_with_parenthesized_let;
     "list literals and patterns", `Quick, test_list_literals_and_patterns_parse;
+    "type annotation with applied tuple type", `Quick, test_type_annotation_with_applied_tuple_type;
   ]

--- a/src/test/test_rizzo.ml
+++ b/src/test/test_rizzo.ml
@@ -128,12 +128,13 @@ let rec expr_has_tvar : type s. s Ast.expr -> bool = function
 let program_has_tvar (program : _ Ast.program) : bool =
   List.exists (function
     | Ast.TopLet ((_, name_ann), expr, ann) ->
-        ann_has_tvar name_ann || ann_has_tvar ann || expr_has_tvar expr) program
+        ann_has_tvar name_ann || ann_has_tvar ann || expr_has_tvar expr
+    | Ast.TopTypeDef _ -> false) program
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
   let typed_program, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    let {typed_program; type_errors; _} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
     typed_program, type_errors
   in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
@@ -146,7 +147,7 @@ let test_typecheck_normalizes_inner_annotations () =
       \  let swap_nested_left = fun q -> snd (fst q) in\n\
       \  swap_nested_left\n"
   in
-  let { typed_program; type_errors = errors; _ } : Rizzoc.typing_result = Rizzoc.typecheck program in
+  let { typed_program; type_errors = errors; _ } : TypeCheck.typing_result = TypeCheck.typecheck program in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
   Alcotest.(check bool) "typed program contains no unresolved weak vars" false (program_has_tvar typed_program)
 
@@ -158,10 +159,10 @@ let test_projection_partial_app_survives_refcount () =
       fun entry x =\n\
       \  use snd (1, 2)\n"
   in
-  let { typed_program; type_errors = errors; _ } : Rizzoc.typing_result = Rizzoc.typecheck program in
+  let { typed_program; type_errors = errors; type_definitions } : TypeCheck.typing_result = TypeCheck.typecheck program in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
   let lowered_program = Rizzoc.apply_typed_transforms typed_program in
-  let _ = Rizzoc.ref_count lowered_program in
+  let _ = Rizzoc.ref_count (TypeCheck.type_definitions_to_ctor_mappings type_definitions) lowered_program in
   Alcotest.(check pass) "projection partial application reaches RC" () ()
 
 let test_annotated_list_map_typechecks () =

--- a/src/test/test_rizzo.ml
+++ b/src/test/test_rizzo.ml
@@ -81,8 +81,9 @@ let test_warning () =
 let rec typ_has_tvar = function
   | Ast.TVar _ -> true
   | Ast.TError | Ast.TUnit | Ast.TInt | Ast.TString | Ast.TBool | Ast.TName _ | Ast.TParam _ -> false
-  | Ast.TSignal t | Ast.TLater t | Ast.TDelay t | Ast.TOption t | Ast.TList t | Ast.TChan t -> typ_has_tvar t
-  | Ast.TTuple (t1, t2) | Ast.TSync (t1, t2) -> typ_has_tvar t1 || typ_has_tvar t2
+  | Ast.TSignal t | Ast.TLater t | Ast.TDelay t | Ast.TChan t -> typ_has_tvar t
+  | Ast.TApp (t, ts) -> typ_has_tvar t || List.exists typ_has_tvar ts
+  | Ast.TTuple (t1, t2) -> typ_has_tvar t1 || typ_has_tvar t2
   | Ast.TFun (Ast.Cons1 (front, rest), ret) -> typ_has_tvar front || List.exists typ_has_tvar rest || typ_has_tvar ret
 
 let ann_has_tvar : type s. s Ast.ann -> bool = function

--- a/src/test/test_rizzo.ml
+++ b/src/test/test_rizzo.ml
@@ -132,7 +132,10 @@ let program_has_tvar (program : _ Ast.program) : bool =
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed_program, errors = Rizzoc.typecheck parsed in
+  let typed_program, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
   typed_program
 
@@ -143,7 +146,7 @@ let test_typecheck_normalizes_inner_annotations () =
       \  let swap_nested_left = fun q -> snd (fst q) in\n\
       \  swap_nested_left\n"
   in
-  let typed_program, errors = Rizzoc.typecheck program in
+  let { typed_program; type_errors = errors; _ } : Rizzoc.typing_result = Rizzoc.typecheck program in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
   Alcotest.(check bool) "typed program contains no unresolved weak vars" false (program_has_tvar typed_program)
 
@@ -155,7 +158,7 @@ let test_projection_partial_app_survives_refcount () =
       fun entry x =\n\
       \  use snd (1, 2)\n"
   in
-  let typed_program, errors = Rizzoc.typecheck program in
+  let { typed_program; type_errors = errors; _ } : Rizzoc.typing_result = Rizzoc.typecheck program in
   Alcotest.(check int) "no type errors" 0 (List.length errors);
   let lowered_program = Rizzoc.apply_typed_transforms typed_program in
   let _ = Rizzoc.ref_count lowered_program in

--- a/src/test/test_strings.ml
+++ b/src/test/test_strings.ml
@@ -5,7 +5,7 @@ open Ast_test_helpers
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
   let typed, errors = 
-    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    let {typed_program; type_errors; _} : TypeCheck.typing_result = TypeCheck.typecheck parsed in
     typed_program, type_errors
   in
   Alcotest.(check int) "type errors" 0 (List.length errors);

--- a/src/test/test_strings.ml
+++ b/src/test/test_strings.ml
@@ -4,7 +4,10 @@ open Ast_test_helpers
 
 let parse_and_typecheck input =
   let parsed = Parser.parse_string input in
-  let typed, errors = typecheck parsed in
+  let typed, errors = 
+    let {typed_program; type_errors; _} : Rizzoc.typing_result = typecheck parsed in
+    typed_program, type_errors
+  in
   Alcotest.(check int) "type errors" 0 (List.length errors);
   typed
 

--- a/vscode-rizzo-lsp/syntaxes/rizzo.tmLanguage.json
+++ b/vscode-rizzo-lsp/syntaxes/rizzo.tmLanguage.json
@@ -32,7 +32,7 @@
         },
         {
             "name": "keyword.control.rizzo",
-            "match": "\\b(let|fun|match|with|if|then|else|in)\\b"
+            "match": "\\b(let|fun|match|with|if|then|else|in|type)\\b"
         },
         {
             "name": "constant.language.rizzo",
@@ -53,7 +53,7 @@
         },
         {
             "name": "variable.other.readwrite.rizzo",
-            "match": "\\b(?!let\\b|fun\\b|match\\b|with\\b|if\\b|then\\b|else\\b|in\\b|true\\b|false\\b|never\\b|unit\\b)[a-z_][a-zA-Z0-9_']*\\b"
+            "match": "\\b(?!let\\b|fun\\b|match\\b|with\\b|if\\b|then\\b|else\\b|in\\b|type\\b|true\\b|false\\b|never\\b|unit\\b)[a-z_][a-zA-Z0-9_']*\\b"
         },
         {
             "name": "comment.line.double-slash.rizzo",


### PR DESCRIPTION
This has been mentioned by issue #3.

- Moves all the primitive constructors to Rizzo builtins
- Adds custom types with the syntax:
```ml
type MyTypeName =
  | Constructor1 (fields...)
  | Constructor2 (fields...)
```

