### PR TITLE
Add parser error tokens

### DIFF
--- a/examples/paper.rizz
+++ b/examples/paper.rizz
@@ -18,7 +18,7 @@ fun entry _ =
     let n = 0 in
     let nats_prim = nats' n in
     let show_nat = trigger_l (fun _ n -> n) show_sig (nats_prim) in
-    let _x = console_out_signal ("" :: map_l string_of_int show_nat) in
+    let _ = console_out_signal ("" :: map_l string_of_int show_nat) in
 
-    let _x = quit_at quit_sig in
+    let _ = quit_at quit_sig in
     start_event_loop ()

--- a/src/lib/ast_helpers.ml
+++ b/src/lib/ast_helpers.ml
@@ -22,7 +22,7 @@ and free_vars_expr_no_globals e = free_vars_expr StringSet.empty e
 and free_vars_expr top_decl_names e : StringSet.t = 
   let free_vars_expr = free_vars_expr top_decl_names in  
   match e with
-  | EConst _ -> StringSet.empty
+  | EConst _ | EError _ -> StringSet.empty
   | EVar (x, _) -> StringSet.singleton x
   | ECtor (_, args, _) ->
     List.fold_left StringSet.union StringSet.empty (List.map free_vars_expr args)

--- a/src/lib/ast_private/ast_core.ml
+++ b/src/lib/ast_private/ast_core.ml
@@ -55,6 +55,7 @@ type _ pattern =
   | PWildcard : 's ann -> 's pattern
   | PVar : string * 's ann -> 's pattern
   | PConst : const * 's ann -> 's pattern
+  | PError : string * 's ann -> 's pattern
   | PTuple : 's pattern * 's pattern * 's ann -> 's pattern
   | PSigCons : 's pattern * 's name * 's ann -> 's pattern
   | PStringCons : 's pattern * 's name * 's ann -> 's pattern
@@ -62,6 +63,7 @@ type _ pattern =
 
 and _ expr =
   | EConst : const * 's ann -> 's expr
+  | EError : string * 's ann -> 's expr
   | EVar : 's name -> 's expr
   | ECtor : 's name * 's expr list * 's ann -> 's expr
   | ELet : 's name * 's expr * 's expr * 's ann -> 's expr
@@ -109,10 +111,10 @@ let expr_get_ann : type stage. stage expr -> stage ann = fun e ->
   | EConst (_, ann) | EVar (_, ann) | ECtor (_, _, ann) | ELet (_, _, _, ann) | EFun (_, _, ann)
   | EApp (_, _, ann) | EUnary (_, _, ann) | EBinary (_, _, _, ann)
   | ETuple (_, _, ann) | ECase (_, _, ann) | EIfe (_, _, _, ann)
-  | EAnno (_, _, ann) -> ann
+  | EAnno (_, _, ann) | EError (_, ann) -> ann
 
 let rec pattern_bound_vars_with_anns : type stage. stage pattern -> (string * stage ann) list = function
-  | PWildcard _ | PConst _ -> []
+  | PWildcard _ | PConst _ | PError _ -> []
   | PVar (x, ann) -> [x, ann]
   | PSigCons (p1, p2, _) | PStringCons (p1, p2, _) -> pattern_bound_vars_with_anns p1 @ [p2]
   | PTuple (p1, p2, _) -> pattern_bound_vars_with_anns p1 @ pattern_bound_vars_with_anns p2
@@ -123,6 +125,7 @@ let pattern_bound_vars pattern =
 
 let pattern_get_ann = function
   | PWildcard ann | PConst (_, ann)
+  | PError (_, ann)
   | PVar (_, ann) | PSigCons (_,_ , ann) | PStringCons (_,_, ann) 
   | PTuple (_, _, ann)
   | PCtor (_, _, ann) -> ann

--- a/src/lib/ast_private/ast_eq.ml
+++ b/src/lib/ast_private/ast_eq.ml
@@ -3,6 +3,7 @@ open! Ast_core
 let rec eq_expr a b =
   match a, b with
   | EConst (c1, _), EConst (c2, _) -> c1 = c2
+  | EError (msg1, _), EError (msg2, _) -> String.equal msg1 msg2
   | EVar (x1, _), EVar (x2, _) -> x1 = x2
   | ECtor (name1, args1, _), ECtor (name2, args2, _) ->
     eq_name name1 name2 && List.length args1 = List.length args2 && List.for_all2 eq_expr args1 args2
@@ -27,6 +28,7 @@ and eq_pattern a b =
   | PWildcard _, PWildcard _ -> true
   | PVar (x1, _), PVar (x2, _) -> x1 = x2
   | PConst (c1, _), PConst (c2, _) -> c1 = c2
+  | PError (msg1, _), PError (msg2, _) -> String.equal msg1 msg2
   | PTuple (a1, b1, _), PTuple (a2, b2, _) -> eq_pattern a1 a2 && eq_pattern b1 b2
   | PSigCons (a1, b1, _), PSigCons (a2, b2, _) -> eq_pattern a1 a2 && eq_name b1 b2
   | PStringCons (a1, b1, _), PStringCons (a2, b2, _) -> eq_pattern a1 a2 && eq_name b1 b2

--- a/src/lib/ast_private/ast_pp.ml
+++ b/src/lib/ast_private/ast_pp.ml
@@ -11,6 +11,7 @@ let rec pp_pattern out = function
   | PWildcard _ -> Format.fprintf out "@{<lightcyan>_@}"
   | PVar (x, _) -> Format.fprintf out "@{<lightcyan>%s@}" x
   | PConst (c, _) -> pp_const out c
+  | PError (msg, _) -> Format.fprintf out "@{<red><parse-error: %s>@}" msg
   | PTuple (p1, p2, _) -> Format.fprintf out "(%a, %a)" pp_pattern p1 pp_pattern p2
   | PSigCons (p1, p2, _) -> Format.fprintf out "(%a :: @{<lightcyan>%s@})" pp_pattern p1 (fst p2)
   | PStringCons (p1, p2, _) -> Format.fprintf out "(%a :: @{<lightcyan>%s@})" pp_pattern p1 (fst p2)
@@ -26,6 +27,7 @@ and pp_expr out =
   let open Format in
   function
   | EConst (c, _) -> pp_const out c
+  | EError (msg, _) -> fprintf out "@{<red><parse-error: %s>@}" msg
   | EVar (x, _) -> fprintf out "@{<lightcyan>%s@}" x
   | ECtor (name, args, _) ->
     if List.length args = 0 then fprintf out "@{<green>%s@}" (fst name)
@@ -113,6 +115,7 @@ and pp_typed_expr out : typed expr -> unit =
   let open Format in
   function
   | EConst (c, _) -> Format.fprintf out "%a" pp_const c
+  | EError (msg, _) -> Format.fprintf out "@{<red><parse-error: %s>@}" msg
   | EVar (x, _) -> Format.fprintf out "@{<lightcyan>%s@}" x
   | ECtor (name, args, _) ->
     if List.length args = 0 then Format.fprintf out "@{<green>%s@}" (fst name)

--- a/src/lib/language_service.ml
+++ b/src/lib/language_service.ml
@@ -1987,6 +1987,11 @@ let semantic_tokens ~(uri : string) ~(filename : string option) ~(text : string)
               | Some keyword_range -> push_token ~kind:SemanticFunction ~range:keyword_range
               | None -> ());
              walk_expr env e
+        | Ast.EUnary (Ast.UTail, e, _) ->
+          (match keyword_range_from_expr ~text ~name:"tail" expr with
+            | Some keyword_range -> push_token ~kind:SemanticFunction ~range:keyword_range
+            | None -> ());
+           walk_expr env e
           | Ast.EUnary (Ast.UDelay, e, _) ->
             (match keyword_range_from_expr ~text ~name:"delay" expr with
                | Some keyword_range -> push_token ~kind:SemanticFunction ~range:keyword_range

--- a/src/lib/language_service.ml
+++ b/src/lib/language_service.ml
@@ -464,7 +464,7 @@ let top_level_constructor_declarations : type s.
       fun f expr ->
       f expr;
       match expr with
-      | Ast.EConst _ | Ast.EVar _ -> ()
+      | Ast.EConst _ | Ast.EError _ | Ast.EVar _ -> ()
       | Ast.ECtor (_, args, _) ->
         List.iter (iter_expr f) args
       | Ast.ELet (_, e1, e2, _) ->
@@ -575,6 +575,7 @@ let hover_text_for_expr : type s. s Ast.expr -> string =
            | Ast.CInt n -> string_of_int n
            | Ast.CBool b -> if b then "true" else "false"
            | Ast.CString s -> s)
+      | Ast.EError (msg, _) -> "parse error " ^ msg
       | Ast.EVar (name, _) -> "variable " ^ name
       | Ast.ECtor ((name, _), _, _) -> "constructor " ^ name
       | Ast.ELet ((name, _), _, _, _) -> "let-binding " ^ name
@@ -594,7 +595,7 @@ let hover_text_for_expr : type s. s Ast.expr -> string =
 let rec pattern_bound_decls : type s. s Ast.pattern -> (string * range) list =
   fun pat ->
     match pat with
-    | Ast.PWildcard _ | Ast.PConst _ -> []
+    | Ast.PWildcard _ | Ast.PConst _ | Ast.PError _ -> []
     | Ast.PVar (name, ann) -> [ (name, range_of_ann ann) ]
   | Ast.PSigCons (p1, p2, _) | Ast.PStringCons (p1, p2, _) ->
         pattern_bound_decls p1 @ [ (fst p2, range_of_ann (snd p2)) ]
@@ -606,7 +607,7 @@ let rec pattern_bound_decls : type s. s Ast.pattern -> (string * range) list =
   let rec pattern_constructor_occurrences : type s. s Ast.pattern -> (string * range) list =
     fun pat ->
     match pat with
-    | Ast.PWildcard _ | Ast.PConst _ | Ast.PVar _ -> []
+    | Ast.PWildcard _ | Ast.PConst _ | Ast.PVar _ | Ast.PError _ -> []
     | Ast.PSigCons (p1, _, _) | Ast.PStringCons (p1, _, _) ->
       pattern_constructor_occurrences p1
     | Ast.PTuple (p1, p2, _) ->
@@ -618,7 +619,7 @@ let rec pattern_bound_decls : type s. s Ast.pattern -> (string * range) list =
 let rec pattern_bound_symbols : type s. s Ast.pattern -> (string * completion_symbol) list =
   fun pat ->
     match pat with
-    | Ast.PWildcard _ | Ast.PConst _ -> []
+    | Ast.PWildcard _ | Ast.PConst _ | Ast.PError _ -> []
     | Ast.PVar (name, ann) ->
         [
           ( name,
@@ -648,7 +649,7 @@ let rec pattern_bound_symbols : type s. s Ast.pattern -> (string * completion_sy
   let rec pattern_bound_names : type s. s Ast.pattern -> s Ast.name list =
     fun pat ->
     match pat with
-    | Ast.PWildcard _ | Ast.PConst _ -> []
+    | Ast.PWildcard _ | Ast.PConst _ | Ast.PError _ -> []
     | Ast.PVar (name, ann) -> [ (name, ann) ]
     | Ast.PSigCons (p1, p2, _) | Ast.PStringCons (p1, p2, _) ->
       pattern_bound_names p1 @ [ p2 ]
@@ -660,7 +661,7 @@ let rec pattern_bound_symbols : type s. s Ast.pattern -> (string * completion_sy
 let rec pattern_constructor_ranges : type s. s Ast.pattern -> range list =
   fun pat ->
     match pat with
-    | Ast.PWildcard _ | Ast.PConst _ | Ast.PVar _ -> []
+    | Ast.PWildcard _ | Ast.PConst _ | Ast.PVar _ | Ast.PError _ -> []
   | Ast.PSigCons (p1, _, _) | Ast.PStringCons (p1, _, _) ->
         pattern_constructor_ranges p1
     | Ast.PTuple (p1, p2, _) ->
@@ -684,6 +685,7 @@ let rec pattern_hover_at_position : type s. position:position -> s Ast.pattern -
         else
           None
     | Ast.PConst (_, _) -> None
+    | Ast.PError (_, _) -> None
     | Ast.PTuple (p1, p2, _) ->
         (match pattern_hover_at_position ~position p1 with
          | Some _ as hover -> hover
@@ -814,7 +816,7 @@ let definition_at_position ~(uri : string) ~(filename : string option) ~(text : 
       in
       let rec find_in_expr (env : definition_symbol StringMap.t) (expr : _ Ast.expr) : definition option =
         match expr with
-        | Ast.EConst _ -> None
+        | Ast.EConst _ | Ast.EError _ -> None
         | Ast.EVar var_name ->
             let var_range = range_of_name var_name in
             if range_contains_position var_range position then
@@ -1046,7 +1048,7 @@ let rename_at_position ~(uri : string) ~(filename : string option) ~(text : stri
       in
       let rec resolve_in_expr (env : rename_target StringMap.t) (expr : _ Ast.expr) : (rename_target * range) option =
         match expr with
-        | Ast.EConst _ -> None
+        | Ast.EConst _ | Ast.EError _ -> None
         | Ast.EVar var_name ->
             let var_range = range_of_name var_name in
             if range_contains_position var_range position then
@@ -1235,7 +1237,7 @@ let rename_at_position ~(uri : string) ~(filename : string option) ~(text : stri
           in
           let rec collect_expr_ranges (env : rename_target StringMap.t) (acc : range list) (expr : Ast.typed Ast.expr) : range list =
             match expr with
-            | Ast.EConst _ -> acc
+            | Ast.EConst _ | Ast.EError _ -> acc
             | Ast.EVar var_name ->
                 let var_range = range_of_name var_name in
                 let acc =
@@ -1428,7 +1430,7 @@ let hover_at_position ~(uri : string) ~(filename : string option) ~(text : strin
           let rec find_symbol_hover_in_expr : type s. StringSet.t -> s Ast.expr -> hover_info option =
             fun local_names expr ->
               match expr with
-              | Ast.EConst _ -> None
+              | Ast.EConst _ | Ast.EError _ -> None
               | Ast.EVar var_name ->
                   let var_range = range_of_name var_name in
                   if range_contains_position var_range position then
@@ -1768,7 +1770,7 @@ let completions_at_position
           None
         else
           match expr with
-          | Ast.EConst _ | Ast.EVar _ -> Some env
+          | Ast.EConst _ | Ast.EError _ | Ast.EVar _ -> Some env
           | Ast.ECtor (ctor_name, args, _) ->
               if range_contains_position (range_of_name ctor_name) position then
                 Some env
@@ -1935,7 +1937,7 @@ let semantic_tokens ~(uri : string) ~(filename : string option) ~(text : string)
       in
       let rec walk_expr (env : scoped_symbol StringMap.t) (expr : Ast.typed Ast.expr) : unit =
         (match expr with
-         | Ast.EConst _ -> ()
+         | Ast.EConst _ | Ast.EError _ -> ()
          | Ast.EVar var_name ->
              let name = name_text var_name in
              let kind =

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -37,7 +37,7 @@ let cons_expr start_pos end_pos head tail =
   ECtor (("Cons", mkloc start_pos end_pos), [head; tail], mkloc start_pos end_pos)
 
 let syntax_error_expr msg start_pos end_pos =
-  EError (msg, mkloc start_pos end_pos)
+  EError (msg, mkloc start_pos end_pos) 
 
 let rec list_expr_of_list start_pos end_pos = function
   | [] -> nil_expr start_pos end_pos
@@ -106,10 +106,10 @@ top_exprs:
 
 top_expr:
   | effect_dec=option(EFFECTFUL) 
-    LET name=ID te_opt=option(type_annotation) EQ body=expr
+    LET name=let_name te_opt=option(type_annotation) EQ body=expr
     { 
-      if Option.is_some effect_dec then Effectful.mark_effectful name;
-      let top_name = (name, mkloc $startpos(name) $endpos(name)) in
+      if Option.is_some effect_dec then Effectful.mark_effectful (fst name);
+      let top_name = name in
       match te_opt with
       | None -> TopLet (top_name, body, mkloc $symbolstartpos $endpos(body)) 
       | Some (te, anno_loc) ->
@@ -144,18 +144,22 @@ type_ctor:
     { let ctor_name = (ctor_name, mkloc $startpos(ctor_name) $endpos(ctor_name)) in
       (ctor_name, ctor_args, mkloc $startpos $endpos) }
 
+let_name:
+  | name=ID { (name, mkloc $startpos(name) $endpos(name)) }
+  | UNDERSCORE { ("_", mkloc $startpos $endpos) }
+
 expr:
-  | LET x=ID te_opt=option(type_annotation) eq=EQ in_kw=IN e2=expr
+  | LET x=let_name te_opt=option(type_annotation) eq=EQ in_kw=IN e2=expr
     {
       let _ = eq, in_kw in
-      let name = (x, mkloc $startpos(x) $endpos(x)) in
+      let name = x in
       let missing_rhs = EError ("Syntax error: expected expression after '='.", mkloc $endpos(eq) $startpos(in_kw)) in
       match te_opt with
       | None    -> ELet (name, missing_rhs, e2, mkloc $startpos $endpos)
       | Some (te, anno_loc) -> ELet (name, EAnno(missing_rhs, te, anno_loc), e2, mkloc $startpos $endpos)
     }
-  | LET x=ID te_opt=option(type_annotation) EQ e1=expr IN e2=expr
-    { let name = (x, mkloc $startpos(x) $endpos(x)) in
+  | LET x=let_name te_opt=option(type_annotation) EQ e1=expr IN e2=expr
+    { let name = x in
       match te_opt with
       | None    -> ELet (name, e1, e2, mkloc $startpos $endpos) 
       | Some (te, anno_loc) -> ELet (name, EAnno(e1, te, anno_loc), e2, mkloc $startpos $endpos) 

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -89,8 +89,10 @@ let rec list_pattern_of_list start_pos end_pos = function
 
 %nonassoc BELOW_BAR
 %nonassoc BELOW_CTOR_ARGS
+%nonassoc MISSING_EXPR
 %nonassoc LPAREN
 %nonassoc BAR
+%nonassoc LET FUN
 // %left PIPE_GT EQEQ
 
 %%
@@ -158,26 +160,20 @@ expr:
       | None    -> ELet (name, e1, e2, mkloc $startpos $endpos) 
       | Some (te, anno_loc) -> ELet (name, EAnno(e1, te, anno_loc), e2, mkloc $startpos $endpos) 
     }
-  | IF e1=expr THEN e2=expr ELSE e3=expr
-    { EIfe (e1, e2, e3, mkloc $startpos $endpos) }
-  | IF e1=expr then_kw=THEN else_kw=ELSE e3=expr
+  | IF e1=expr then_kw=THEN e2=if_then_body else_kw=ELSE e3=if_else_body
     {
       let _ = then_kw, else_kw in
-      let missing_then = syntax_error_expr "Syntax error: expected expression after 'then'." $endpos(then_kw) $startpos(else_kw) in
-      EIfe (e1, missing_then, e3, mkloc $startpos $endpos)
-    }
-  | IF e1=expr then_kw=THEN else_kw=ELSE
-    {
-      let _ = then_kw, else_kw in
-      let missing_then = syntax_error_expr "Syntax error: expected expression after 'then'." $endpos(then_kw) $startpos(else_kw) in
-      let missing_else = syntax_error_expr "Syntax error: expected expression after 'else'." $endpos(else_kw) $endpos(else_kw) in
-      EIfe (e1, missing_then, missing_else, mkloc $startpos $endpos)
-    }
-  | IF e1=expr THEN e2=expr else_kw=ELSE
-    {
-      let _ = else_kw in
-      let missing_else = syntax_error_expr "Syntax error: expected expression after 'else'." $endpos(else_kw) $endpos(else_kw) in
-      EIfe (e1, e2, missing_else, mkloc $startpos $endpos)
+      let e2 =
+        match e2 with
+        | Some e -> e
+        | None -> syntax_error_expr "Syntax error: expected expression after 'then'." $endpos(then_kw) $startpos(else_kw)
+      in
+      let e3 =
+        match e3 with
+        | Some e -> e
+        | None -> syntax_error_expr "Syntax error: expected expression after 'else'." $endpos(else_kw) $endpos(else_kw)
+      in
+      EIfe (e1, e2, e3, mkloc $startpos $endpos)
     }
   | MATCH scrutinee=expr WITH leading=opt_leading_bar first=match_case rest=match_case_tail
     { let _ = leading in ECase (scrutinee, first :: rest, mkloc $startpos $endpos) }
@@ -196,10 +192,18 @@ opt_leading_bar:
   | { () }
   | BAR { () }
 
+if_then_body:
+  | e=expr { Some e }
+  | { None }
+
+if_else_body:
+  | e=expr { Some e }
+  | %prec MISSING_EXPR { None }
+
 match_case:
   | p=pattern ARROW e=expr
   { (p, e, mkloc $startpos $endpos) }
-  | p=pattern arrow=ARROW
+  | p=pattern arrow=ARROW %prec MISSING_EXPR
   {
     let _ = arrow in
     let missing_body = syntax_error_expr "Syntax error: expected expression after '->'." $endpos(arrow) $endpos(arrow) in

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -36,6 +36,9 @@ let nil_expr start_pos end_pos =
 let cons_expr start_pos end_pos head tail =
   ECtor (("Cons", mkloc start_pos end_pos), [head; tail], mkloc start_pos end_pos)
 
+let syntax_error_expr msg start_pos end_pos =
+  EError (msg, mkloc start_pos end_pos)
+
 let rec list_expr_of_list start_pos end_pos = function
   | [] -> nil_expr start_pos end_pos
   | head :: tail -> cons_expr start_pos end_pos head (list_expr_of_list start_pos end_pos tail)
@@ -157,8 +160,33 @@ expr:
     }
   | IF e1=expr THEN e2=expr ELSE e3=expr
     { EIfe (e1, e2, e3, mkloc $startpos $endpos) }
+  | IF e1=expr then_kw=THEN else_kw=ELSE e3=expr
+    {
+      let _ = then_kw, else_kw in
+      let missing_then = syntax_error_expr "Syntax error: expected expression after 'then'." $endpos(then_kw) $startpos(else_kw) in
+      EIfe (e1, missing_then, e3, mkloc $startpos $endpos)
+    }
+  | IF e1=expr then_kw=THEN else_kw=ELSE
+    {
+      let _ = then_kw, else_kw in
+      let missing_then = syntax_error_expr "Syntax error: expected expression after 'then'." $endpos(then_kw) $startpos(else_kw) in
+      let missing_else = syntax_error_expr "Syntax error: expected expression after 'else'." $endpos(else_kw) $endpos(else_kw) in
+      EIfe (e1, missing_then, missing_else, mkloc $startpos $endpos)
+    }
+  | IF e1=expr THEN e2=expr else_kw=ELSE
+    {
+      let _ = else_kw in
+      let missing_else = syntax_error_expr "Syntax error: expected expression after 'else'." $endpos(else_kw) $endpos(else_kw) in
+      EIfe (e1, e2, missing_else, mkloc $startpos $endpos)
+    }
   | MATCH scrutinee=expr WITH leading=opt_leading_bar first=match_case rest=match_case_tail
     { let _ = leading in ECase (scrutinee, first :: rest, mkloc $startpos $endpos) }
+  | match_kw=MATCH with_kw=WITH leading=opt_leading_bar first=match_case rest=match_case_tail
+    {
+      let _ = match_kw, with_kw, leading in
+      let missing_scrutinee = syntax_error_expr "Syntax error: expected expression after 'match'." $endpos(match_kw) $startpos(with_kw) in
+      ECase (missing_scrutinee, first :: rest, mkloc $startpos $endpos)
+    }
   | FUN params=pattern_atom+ ARROW body=expr
     { (* check_unique_params (List.map fst params); *) EFun (params, body, mkloc $startpos $endpos) }
   | e=pipe_expr
@@ -171,6 +199,12 @@ opt_leading_bar:
 match_case:
   | p=pattern ARROW e=expr
   { (p, e, mkloc $startpos $endpos) }
+  | p=pattern arrow=ARROW
+  {
+    let _ = arrow in
+    let missing_body = syntax_error_expr "Syntax error: expected expression after '->'." $endpos(arrow) $endpos(arrow) in
+    (p, missing_body, mkloc $startpos $endpos)
+  }
 
 match_case_tail:
   | { [] } %prec BELOW_BAR

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -140,6 +140,15 @@ type_ctor:
       (ctor_name, ctor_args, mkloc $startpos $endpos) }
 
 expr:
+  | LET x=ID te_opt=option(type_annotation) eq=EQ in_kw=IN e2=expr
+    {
+      let _ = eq, in_kw in
+      let name = (x, mkloc $startpos(x) $endpos(x)) in
+      let missing_rhs = EError ("Syntax error: expected expression after '='.", mkloc $endpos(eq) $startpos(in_kw)) in
+      match te_opt with
+      | None    -> ELet (name, missing_rhs, e2, mkloc $startpos $endpos)
+      | Some (te, anno_loc) -> ELet (name, EAnno(missing_rhs, te, anno_loc), e2, mkloc $startpos $endpos)
+    }
   | LET x=ID te_opt=option(type_annotation) EQ e1=expr IN e2=expr
     { let name = (x, mkloc $startpos(x) $endpos(x)) in
       match te_opt with

--- a/src/lib/transforms/anf.ml
+++ b/src/lib/transforms/anf.ml
@@ -1,8 +1,7 @@
 open Ast
 
 let is_name = function
-| EVar _ -> true
-| EConst _ -> true
+| EConst _ | EVar _ | EError _ -> true
 | _ -> false
 
 let new_var () = Utilities.new_var ()
@@ -10,7 +9,7 @@ let new_var () = Utilities.new_var ()
 (* Pretty much exactly: Flanagan et. al 1993 *)
 let rec normalize_expr m = normalize m Fun.id
 and normalize (m: _ expr) k = match m with
-| EConst _ | EVar _ -> k m
+| EConst _ | EVar _ | EError _ -> k m
 | ECtor (name, args, loc) ->
   normalize_name_mult args (fun args' -> k (ECtor (name, args', loc)))
 | EFun (params, body, loc) -> k (EFun (params, normalize_expr body, loc))

--- a/src/lib/transforms/consecutive_lambda.ml
+++ b/src/lib/transforms/consecutive_lambda.ml
@@ -19,7 +19,7 @@ let rec collect_consecutive_params params body =
 
 let rec eliminate_consecutive_lambdas_expr (e : _ expr) : _ expr =
   match e with
-  | EConst _ | EVar _ -> e
+  | EConst _ | EVar _ | EError _ -> e
   | ECtor (name, args, loc) ->
       ECtor (name, List.map eliminate_consecutive_lambdas_expr args, loc)
   | ELet (x, e1, e2, loc) ->

--- a/src/lib/transforms/copy_propagation.ml
+++ b/src/lib/transforms/copy_propagation.ml
@@ -66,7 +66,7 @@ let eliminate_copy_propagation (e: _ expr) : _ expr =
   in
   let rec aux (env: (string * _ expr) list) (e: _ expr) : _ expr =
     match e with
-    | EConst _ -> e
+    | EConst _ | EError _ -> e
     | EVar (x, _) -> Option.value (List.assoc_opt x env) ~default:e
     | ECtor (name, args, ann) -> ECtor (name, List.map (aux env) args, ann)
     | EApp (f, args, ann) ->

--- a/src/lib/transforms/dead_let_elimination.ml
+++ b/src/lib/transforms/dead_let_elimination.ml
@@ -3,7 +3,7 @@ open Collections
 
 let rec has_effectful_call (e : _ expr) : bool =
 	match e with
-	| EConst _ | EVar _ -> false
+	| EConst _ | EVar _ | EError _ -> false
 	| ECtor (_, args, _) -> List.exists has_effectful_call args
 	| EApp (f, args, _) ->
 			let direct_effectful =
@@ -26,7 +26,7 @@ let rec has_effectful_call (e : _ expr) : bool =
 
 let rec eliminate_dead_let (e : _ expr) : _ expr =
 	match e with
-	| EConst _ | EVar _ -> e
+	| EConst _ | EVar _ | EError _ -> e
 	| ECtor (name, args, ann) -> ECtor (name, List.map eliminate_dead_let args, ann)
 	| EApp (f, args, ann) -> EApp (eliminate_dead_let f, List.map eliminate_dead_let args, ann)
 	| EUnary (op, e, ann) -> EUnary (op, eliminate_dead_let e, ann)

--- a/src/lib/transforms/explicit_lifts.ml
+++ b/src/lib/transforms/explicit_lifts.ml
@@ -17,7 +17,7 @@ let top_level_function_name = function
 let rec rewrite_expr function_names bound_names ~as_callee = function
   | EVar (((name, _) as var_name)) when (not as_callee) && StringSet.mem name function_names && not (StringSet.mem name bound_names) ->
       EApp (EVar var_name, [], snd var_name)
-  | EConst _ | EVar _ as expr -> expr
+  | EConst _ | EVar _ | EError _ as expr -> expr
   | ECtor (name, args, ann) ->
       ECtor (name, List.map (rewrite_expr function_names bound_names ~as_callee:false) args, ann)
   | ELet (((name, _) as bound_name), rhs, body, ann) ->

--- a/src/lib/transforms/lambda_lifting.ml
+++ b/src/lib/transforms/lambda_lifting.ml
@@ -26,7 +26,7 @@ and lift_top_expr top_names (lifted_lambdas: _ top_expr list ref) (te: _ top_exp
 and lift_expr top_names (lifted_lambdas: _ top_expr list ref) (e: _ expr) = 
   let lift_expr = lift_expr top_names lifted_lambdas in
   match e with
-  | EConst _ | EVar _ -> e
+  | EConst _ | EVar _ | EError _ -> e
   | ECtor (name, args, loc) -> ECtor (name, List.map lift_expr args, loc)
   | EApp (f, args, loc) -> EApp (lift_expr f, List.map lift_expr args, loc)
   | EBinary (op, e1, e2, loc) -> EBinary (op, lift_expr e1, lift_expr e2, loc)

--- a/src/lib/transforms/patterns.ml
+++ b/src/lib/transforms/patterns.ml
@@ -12,7 +12,7 @@ let app ((name, ann) : _ name) args =
 	EApp (var (name, ann), args, ann)
   
   let is_simple_expr = function
-	| EVar _ | EConst _ -> true
+	| EVar _ | EConst _ | EError _ -> true
 	| _ -> false
   
 let match_fail = (Rizzo_builtins.get "match_fail").name
@@ -28,6 +28,7 @@ let rec transform_patterns (program: 's Ast.program) =
 and compile_pattern p scrutinee good bad =
 	match p with
 	| PWildcard _ -> good scrutinee
+	| PError _ -> bad ()
 	| PVar (name, ann) ->
 		ELet ((name, ann), scrutinee, good (EVar (name, ann)), ann)
 	| PConst (CString s, ann) ->
@@ -124,7 +125,7 @@ and compile_match_cases scrutinee cases =
 
 and compile_match e =
 	match e with
-	| EVar _ | EConst _ -> e
+	| EVar _ | EConst _ | EError _ -> e
 	| ECtor (name, args, ann) -> ECtor (name, List.map compile_match args, ann)
 	| ECase (scrutinee, cases, ann) ->
 		let scrutinee = compile_match scrutinee in

--- a/src/lib/transforms/patterns_tree.ml
+++ b/src/lib/transforms/patterns_tree.ml
@@ -23,7 +23,7 @@ let app ((name, ann) : _ name) args = EApp (var (name, ann), args, ann)
 let proj index ann expr = EUnary (UProj index, expr, ann)
 
 let is_simple_expr = function
-	| EVar _ | EConst _ -> true
+	| EVar _ | EConst _ | EError _ -> true
 	| _ -> false
 
 let match_fail ann message = app (match_fail_name, ann) [EConst (CString message, ann)]
@@ -33,7 +33,7 @@ let rec sink_until_first_use name proj ann expr =
 	let used_in expr = Collections.StringSet.mem var_name (Ast_helpers.free_vars_expr_no_globals expr) in
 	match expr with
 	| EVar (n1, _) when var_name = n1 -> ELet (name, proj, expr, ann)
-	| EVar _ | EConst _ -> expr
+	| EVar _ | EConst _ | EError _ -> expr
 	| ELet (name', rhs, body, ann') ->
 		if used_in rhs then ELet (name, proj, expr, ann)
 		else ELet (name', rhs, sink_until_first_use name proj ann body, ann')
@@ -106,6 +106,7 @@ let normalize_clause clause =
 			(fun var entry acc ->
 				 match entry.pat with
 				 | PWildcard _ -> acc
+				 | PError _ -> acc
 				 | PVar (name, ann) ->
 					 bindings := { name; source = var; ann; sink = entry.sink_binding } :: !bindings;
 					 acc
@@ -116,7 +117,7 @@ let normalize_clause clause =
 	{ clause with pats; bindings = List.rev !bindings }
 
 let is_tree_testable = function
-	| PWildcard _ | PVar _ | PStringCons _ -> false
+	| PWildcard _ | PVar _ | PStringCons _ | PError _ -> false
 	| _ -> true
 
 let same_test_pattern left right =
@@ -129,7 +130,6 @@ let same_test_pattern left right =
 	| _ -> false
 
 let test_fresh_vars = function
-	| PConst _ -> []
 	| PTuple _ -> [Utilities.new_name "tuple_left"; Utilities.new_name "tuple_right"]
 	| PCtor (_, args, _) -> List.init (List.length args) (fun _ -> Utilities.new_name "ctor_field")
 	| PSigCons _ -> [Utilities.new_name "sig_head"; Utilities.new_name "sig_tail"]
@@ -152,6 +152,7 @@ and compile_string_branches lower scrutinee cases ann =
 and compile_string_pattern lower scrutinee pattern success next ann =
 	match pattern with
 	| PWildcard _ -> success
+	| PError _ -> next ()
 	| PVar (name, name_ann) -> ELet ((name, name_ann), scrutinee, success, ann)
 	| PConst (CString s, patt_ann) ->
 		EIfe (app (string_eq, ann) [scrutinee; EConst (CString s, patt_ann)], success, next (), ann)
@@ -304,6 +305,8 @@ let emit_test ann branch_var test_pat fresh_vars yes no =
 		| _ -> failwith "Signal-cons tests expect two field variables")
 	| PStringCons _ ->
 		failwith "String-cons patterns should be lowered by the string pass"
+	| PError _ ->
+		no
 	| PWildcard _ | PVar _ ->
 		failwith "Unexpected non-test pattern in emit_test"
 
@@ -354,7 +357,7 @@ and compile_tree_case lower scrutinee cases ann =
 
 and compile_match e =
 	match e with
-	| EVar _ | EConst _ -> e
+	| EVar _ | EConst _ | EError _ -> e
 	| ECtor (name, args, ann) -> ECtor (name, List.map compile_match args, ann)
 	| ECase (scrutinee, cases, ann) when is_string_case cases ->
 		compile_string_case compile_match scrutinee cases ann
@@ -376,7 +379,7 @@ and compile_match e =
 		let body' = List.fold_right (
 			fun (scrutinee_var, pattern_ann, pattern) acc -> 
 				match pattern with
-				| PVar _ | PWildcard _ -> acc
+				| PVar _ | PWildcard _ | PError _ -> acc
 				| _ -> 
 					compile_tree_rows compile_match pattern_ann [ {
 						pats = StringMap.singleton scrutinee_var (clause_pat pattern);

--- a/src/lib/transforms/pure_to_rc.ml
+++ b/src/lib/transforms/pure_to_rc.ml
@@ -141,6 +141,7 @@ and expr_to_fn_body ctor_tag_map globals locals (e : _ expr) : Rc.fn_body =
     let tagof = tagof ctor_tag_map in
     let body = expr_to_fn_body locals branch in
     match pattern with
+    | PError _ -> failwith "Parse error pattern reached RC lowering"
     | PVar _ | PWildcard _ -> case_arm body
     | PConst (CBool false, _) -> case_arm ~tag:(tagof "false") ~num_fields:0 body
     | PConst (CBool true, _) -> case_arm ~tag:(tagof "true") ~num_fields:0 body
@@ -166,6 +167,7 @@ and expr_to_fn_body ctor_tag_map globals locals (e : _ expr) : Rc.fn_body =
     aux [] [] cases
   in
   match e with
+  | EError _ -> failwith "Parse error expression reached RC lowering"
   | EVar (x, _) -> FnRet (Var x)
   | EConst (c, _) -> FnRet (Const c)
   | EApp _ | ELet _ -> app_to_fn_body ctor_tag_map globals locals e

--- a/src/lib/transforms/remove_dup_names.ml
+++ b/src/lib/transforms/remove_dup_names.ml
@@ -9,7 +9,7 @@ let rec subst_program (p: _ program) =
 
 and subst (replacement_of : string StringMap.t) (e : 's expr) : 's expr =
   match e with
-  | EConst _ -> e
+  | EConst _ | EError _ -> e
   | EVar (y, ann) when StringMap.mem y replacement_of -> EVar (StringMap.find y replacement_of, ann)
   | EVar _ -> e
   | ELet ((y, y_ann), e1, e2,  ann) when StringMap.mem y replacement_of ->
@@ -73,6 +73,7 @@ and subst_pattern (replacement_of : string StringMap.t) (p : 's pattern) : 's pa
   match p with
   | PWildcard _ -> p
   | PConst _ -> p
+  | PError _ -> p
   | PVar (y, ann) when StringMap.mem y replacement_of -> PVar (StringMap.find y replacement_of, ann)
   | PVar _ -> p
   | PSigCons (p1, (y, y_ann), ann) ->

--- a/src/lib/transforms/simple_patterns.ml
+++ b/src/lib/transforms/simple_patterns.ml
@@ -17,7 +17,7 @@ let parsed_app ((name, ann) : _ name) args =
   EApp (parsed_var (name, ann), args, ann)
 
 let is_simple_expr = function
-  | EVar _ | EConst _ -> true
+  | EVar _ | EConst _ | EError _ -> true
   | _ -> false
 
 let is_string_case_head = function
@@ -43,7 +43,7 @@ let rec sink_until_first_use name proj ann e =
   let used_in e = Collections.StringSet.mem var_name (Ast_helpers.free_vars_expr_no_globals e) in
   match e with
   | EVar (n1,_) when var_name = n1 -> ELet(name, proj, e, ann)
-  | EVar _ | EConst _ -> e
+  | EVar _ | EConst _ | EError _ -> e
   | ELet (name', rhs, e2, ann') -> 
     if used_in rhs then ELet(name, proj, e, ann)
     else ELet (name', rhs, sink_until_first_use name proj ann e2, ann')
@@ -76,6 +76,8 @@ let rec transform_patterns (p: 's Ast.program) =
 and compile_simple_pattern scrutinee case_body = function
   | PWildcard _ ->
     Some (case_body ())
+  | PError _ ->
+    None
   | PVar (s, ann) -> 
     let x = ELet ((s, ann), scrutinee, case_body (), ann) in
     Some (x)
@@ -131,6 +133,7 @@ and compile_string_branches scrutinee cases ann =
 and compile_string_pattern scrutinee pattern success next ann =
   match pattern with
   | PWildcard _ -> success
+  | PError _ -> next ()
   | PVar (name, name_ann) -> ELet ((name, name_ann), scrutinee, success, ann)
   | PConst (CString s, patt_ann) ->
     EIfe (
@@ -166,7 +169,7 @@ and compile_string_cons scrutinee head_pat tail_name success next ann =
 
 and compile_match e = 
   match e with
-  | EVar _ | EConst _ -> e 
+  | EVar _ | EConst _ | EError _ -> e 
   | ECtor (name, args, ann) -> ECtor (name, List.map compile_match args, ann)
   | ECase (scrutinee, cases, ann) when is_string_case cases ->
     compile_string_case scrutinee cases ann

--- a/src/lib/transforms/typed_lowering.ml
+++ b/src/lib/transforms/typed_lowering.ml
@@ -22,6 +22,7 @@ and lower_top_expr = function
 and lower_expr (e : typed expr) : parsed expr =
   match e with
   | EConst (c, ann) -> EConst (c, parsed_ann ann)
+  | EError (msg, ann) -> EError (msg, parsed_ann ann)
   | EVar name -> EVar (parsed_name name)
   | ECtor (name, args, ann) -> ECtor (parsed_name name, List.map lower_expr args, parsed_ann ann)
   | ELet (name, rhs, body, ann) ->
@@ -66,6 +67,7 @@ and lower_pattern : type s. s pattern -> parsed pattern = function
   | PWildcard ann -> PWildcard (parsed_ann ann)
   | PVar (name, ann) -> PVar (name, parsed_ann ann)
   | PConst (c, ann) -> PConst (c, parsed_ann ann)
+  | PError (msg, ann) -> PError (msg, parsed_ann ann)
   | PTuple (p1, p2, ann) -> PTuple (lower_pattern p1, lower_pattern p2, parsed_ann ann)
   | PSigCons (p1, p2, ann) -> PSigCons (lower_pattern p1, parsed_name p2, parsed_ann ann)
   | PStringCons (p1, p2, ann) -> PStringCons (lower_pattern p1, parsed_name p2, parsed_ann ann)

--- a/src/lib/typecheck.ml
+++ b/src/lib/typecheck.ml
@@ -354,6 +354,9 @@ and infer : type stage. stage expr -> typed expr Type_env.t = fun e ->
   | EConst (c, ann) -> 
     let* const_type = infer_const_type ann c in
     return (EConst (c, Ann_typed (get_location ann, const_type)))
+  | EError (msg, ann) ->
+    let* _ = error ann msg in
+    return (EError (msg, Ann_typed (get_location ann, TError)))
   | EAnno (e, t, ann) -> 
     let* () = is_valid_type ann t in
     let* te = check e t in
@@ -676,6 +679,9 @@ and check_pattern : type stage. stage pattern -> typ -> (typed pattern * (string
   | PWildcard ann ->
     let* pattern_type = Type_env.apply_subst expected_type in
     return (PWildcard (Ann_typed (get_location ann, pattern_type)), [])
+  | PError (msg, ann) ->
+    let* _ = error ann msg in
+    return (PError (msg, Ann_typed (get_location ann, TError)), [])
   | PVar (name, ann) ->
     let* pattern_type = Type_env.apply_subst expected_type in
     return (PVar (name, Ann_typed (get_location ann, pattern_type)), [name, mono pattern_type])
@@ -925,6 +931,9 @@ and normalize_typed_pattern id_to_name : typed pattern -> typed pattern Type_env
     let* args = Type_env.collect (List.map (normalize_typed_pattern id_to_name) args) in
     let* ann = normalize_typed_ann id_to_name ann in
     return (PCtor (name, args, ann))
+  | PError (msg, ann) ->
+    let* ann = normalize_typed_ann id_to_name ann in
+    return (PError (msg, ann))
 
 and normalize_typed_expr id_to_name : typed expr -> typed expr Type_env.t = function
   | EConst (c, ann) ->
@@ -990,6 +999,9 @@ and normalize_typed_expr id_to_name : typed expr -> typed expr Type_env.t = func
     let* typ = Type_env.generalize_type_vars ~id_to_name typ in
     let* ann = normalize_typed_ann id_to_name ann in
     return (EAnno (expr, typ, ann))
+  | EError (msg, ann) ->
+    let* ann = normalize_typed_ann id_to_name ann in
+    return (EError (msg, ann))
 
 and normalize_typed_top_expr id_to_name : typed top_expr -> typed top_expr Type_env.t = function
   | TopLet (name, expr, ann) ->

--- a/src/test/ast_test_helpers.ml
+++ b/src/test/ast_test_helpers.ml
@@ -31,6 +31,7 @@ let int (i : int) : parsed expr = EConst (CInt i, ann)
 let str (s : string) : parsed expr = EConst (CString s, ann)
 let bool (b : bool) : parsed expr = EConst (CBool b, ann)
 let const (c : const) : parsed expr = EConst (c, ann)
+let error (msg : string) : parsed expr = EError (msg, ann)
 
 let let_ (n : string) (e1 : parsed expr) (e2 : parsed expr) : parsed expr =
   ELet (name n, e1, e2, ann)

--- a/src/test/test_language_service.ml
+++ b/src/test/test_language_service.ml
@@ -407,6 +407,8 @@ let test_missing_local_let_rhs_keeps_lsp_semantics () =
     ^ "\n"
     ^ "fun entry _ =\n"
     ^ "    let _x =  in\n"
+    ^ "    let _y = match  with | _ ->  in\n"
+    ^ "    let _z = if true then  else  in\n"
     ^ "    start_event_loop ()\n"
   in
   let analysis = Language_service.analyze_document ~uri:"file:///test.rizz" ~filename:None ~text in
@@ -417,20 +419,34 @@ let test_missing_local_let_rhs_keeps_lsp_semantics () =
        (fun (diag : Language_service.diagnostic) ->
          contains_substring ~text:diag.message ~substring:"expected expression after '='")
        analysis.Language_service.diagnostics);
+  Alcotest.(check bool)
+    "reports missing match scrutinee diagnostic"
+    true
+    (List.exists
+       (fun (diag : Language_service.diagnostic) ->
+         contains_substring ~text:diag.message ~substring:"expected expression after 'match'")
+       analysis.Language_service.diagnostics);
+  Alcotest.(check bool)
+    "reports missing if branch diagnostic"
+    true
+    (List.exists
+       (fun (diag : Language_service.diagnostic) ->
+         contains_substring ~text:diag.message ~substring:"expected expression after 'else'")
+       analysis.Language_service.diagnostics);
   let tokens = Language_service.semantic_tokens ~uri:"file:///test.rizz" ~filename:None ~text in
   Alcotest.(check bool)
     "tokens continue after recovered local let"
     true
     (has_semantic_token
        ~tokens
-       ~line:4
+       ~line:6
        ~character:4
        ~kind:Language_service.SemanticFunction
        ~declaration:false);
   let labels =
     completion_labels
       ~text
-      ~position:{ Language_service.line = 4; character = 4 }
+      ~position:{ Language_service.line = 6; character = 4 }
   in
   Alcotest.(check bool)
     "completion still has builtins after recovered local let"

--- a/src/test/test_language_service.ml
+++ b/src/test/test_language_service.ml
@@ -401,6 +401,42 @@ let test_semantic_tokens_include_local_let_declaration () =
        ~kind:Language_service.SemanticVariable
        ~declaration:false)
 
+let test_missing_local_let_rhs_keeps_lsp_semantics () =
+  let text =
+    "let something_that_would_compile = 1 + 2\n"
+    ^ "\n"
+    ^ "fun entry _ =\n"
+    ^ "    let _x =  in\n"
+    ^ "    start_event_loop ()\n"
+  in
+  let analysis = Language_service.analyze_document ~uri:"file:///test.rizz" ~filename:None ~text in
+  Alcotest.(check bool)
+    "reports missing rhs diagnostic"
+    true
+    (List.exists
+       (fun (diag : Language_service.diagnostic) ->
+         contains_substring ~text:diag.message ~substring:"expected expression after '='")
+       analysis.Language_service.diagnostics);
+  let tokens = Language_service.semantic_tokens ~uri:"file:///test.rizz" ~filename:None ~text in
+  Alcotest.(check bool)
+    "tokens continue after recovered local let"
+    true
+    (has_semantic_token
+       ~tokens
+       ~line:4
+       ~character:4
+       ~kind:Language_service.SemanticFunction
+       ~declaration:false);
+  let labels =
+    completion_labels
+      ~text
+      ~position:{ Language_service.line = 4; character = 4 }
+  in
+  Alcotest.(check bool)
+    "completion still has builtins after recovered local let"
+    true
+    (completion_has_label ~labels ~name:"start_event_loop")
+
 let test_semantic_tokens_include_builtin_operators () =
   let text =
     "fun main x =\n"
@@ -990,6 +1026,7 @@ let tests = [
   "missing bracket gives hint", `Quick, test_missing_bracket_reports_hint;
   "semantic tokens MVP", `Quick, test_semantic_tokens_mvp;
   "semantic tokens local let declaration", `Quick, test_semantic_tokens_include_local_let_declaration;
+  "missing local let rhs keeps LSP semantics", `Quick, test_missing_local_let_rhs_keeps_lsp_semantics;
   "semantic tokens builtin operators", `Quick, test_semantic_tokens_include_builtin_operators;
   "semantic tokens builtin function references", `Quick, test_semantic_tokens_include_builtin_function_references;
   "pipe left operand keeps function metadata", `Quick, test_pipe_left_operand_keeps_function_reference_metadata;

--- a/src/test/test_map2.ml
+++ b/src/test/test_map2.ml
@@ -24,7 +24,7 @@ let rec find_typed_let_binding target (e : typed expr) : (typ * typ * typed expr
     (match find_typed_let_binding target rhs with
         | Some _ as found -> found
     | None -> find_typed_let_binding target body)
-  | EConst _ | EVar _ -> None
+  | EConst _ | EError _ | EVar _ -> None
   | ECtor (_, args, _) ->
     List.find_map (find_typed_let_binding target) args
   | EFun (_, body, _) -> find_typed_let_binding target body

--- a/src/test/test_parser.ml
+++ b/src/test/test_parser.ml
@@ -148,6 +148,52 @@ let test_type_annotation_with_applied_tuple_type () =
     Alcotest.(check bool) "annotation parses as expected" true (eq_typ annotated_type expected_type)
   | _ -> Alcotest.fail "expected a single annotated top-level let"
 
+let test_missing_if_branch_expressions_recover () =
+  let input =
+    "let missing_then = if true then else 1\n"
+    ^ "let missing_both = let _z = if true then else in _z\n"
+    ^ "let missing_else = if true then 1 else\n"
+  in
+  let parsed = Rizzoc.Parser.parse_string input in
+  let expected : parsed program =
+    [
+      toplet "missing_then"
+        (ife (bool true)
+           (error "Syntax error: expected expression after 'then'.")
+           (int 1));
+      toplet "missing_both"
+        (let_ "_z"
+           (ife (bool true)
+              (error "Syntax error: expected expression after 'then'.")
+              (error "Syntax error: expected expression after 'else'."))
+           (var "_z"));
+      toplet "missing_else"
+        (ife (bool true)
+           (int 1)
+           (error "Syntax error: expected expression after 'else'."));
+    ]
+  in
+  Alcotest.check program_testable "missing if branch expressions recover" expected parsed
+
+let test_missing_match_parts_recover () =
+  let input =
+    "let missing_scrutinee = match with | _ -> 1\n"
+    ^ "let missing_arm_body = match x with | _ ->\n"
+  in
+  let parsed = Rizzoc.Parser.parse_string input in
+  let expected : parsed program =
+    [
+      toplet "missing_scrutinee"
+        (case
+           (error "Syntax error: expected expression after 'match'.")
+           [ (pwild, int 1) ]);
+      toplet "missing_arm_body"
+        (case (var "x")
+           [ (pwild, error "Syntax error: expected expression after '->'.") ]);
+    ]
+  in
+  Alcotest.check program_testable "missing match parts recover" expected parsed
+
 let parser_tests =
   [
     "parser accepts syntax", `Quick, test_parser_program;
@@ -159,4 +205,6 @@ let parser_tests =
     "constructor application with parenthesized let", `Quick, test_constructor_application_with_parenthesized_let;
     "list literals and patterns", `Quick, test_list_literals_and_patterns_parse;
     "type annotation with applied tuple type", `Quick, test_type_annotation_with_applied_tuple_type;
+    "missing if branch expressions recover", `Quick, test_missing_if_branch_expressions_recover;
+    "missing match parts recover", `Quick, test_missing_match_parts_recover;
   ]

--- a/src/test/test_parser.ml
+++ b/src/test/test_parser.ml
@@ -148,6 +148,21 @@ let test_type_annotation_with_applied_tuple_type () =
     Alcotest.(check bool) "annotation parses as expected" true (eq_typ annotated_type expected_type)
   | _ -> Alcotest.fail "expected a single annotated top-level let"
 
+let test_local_let_accepts_wildcard_name () =
+  let input =
+    "let entry = let _ = console_out_signal s in start_event_loop ()\n"
+  in
+  let parsed = Rizzoc.Parser.parse_string input in
+  let expected : parsed program =
+    [
+      toplet "entry"
+        (let_ "_"
+           (app (var "console_out_signal") [var "s"])
+           (app (var "start_event_loop") [const CUnit]));
+    ]
+  in
+  Alcotest.check program_testable "local let accepts wildcard name" expected parsed
+
 let test_missing_if_branch_expressions_recover () =
   let input =
     "let missing_then = if true then else 1\n"
@@ -205,6 +220,7 @@ let parser_tests =
     "constructor application with parenthesized let", `Quick, test_constructor_application_with_parenthesized_let;
     "list literals and patterns", `Quick, test_list_literals_and_patterns_parse;
     "type annotation with applied tuple type", `Quick, test_type_annotation_with_applied_tuple_type;
+    "local let accepts wildcard name", `Quick, test_local_let_accepts_wildcard_name;
     "missing if branch expressions recover", `Quick, test_missing_if_branch_expressions_recover;
     "missing match parts recover", `Quick, test_missing_match_parts_recover;
   ]

--- a/src/test/test_patterns.ml
+++ b/src/test/test_patterns.ml
@@ -7,7 +7,7 @@ let rec count_let_bindings target = function
       (if String.equal name target then 1 else 0)
       + count_let_bindings target rhs
       + count_let_bindings target body
-  | EConst _ | EVar _ -> 0
+  | EConst _ | EVar _ | EError _ -> 0
   | ECtor (_, args, _) -> List.fold_left (fun acc e -> acc + count_let_bindings target e) 0 args
   | EApp (fn, args, _) ->
       count_let_bindings target fn
@@ -33,7 +33,7 @@ let rec count_let_bindings_prefix prefix : _ expr -> int = function
     (if matches_prefix then 1 else 0)
     + count_let_bindings_prefix prefix rhs
     + count_let_bindings_prefix prefix body
-  | EConst _ | EVar _ -> 0
+  | EConst _ | EVar _ | EError _ -> 0
   | ECtor (_, args, _) -> List.fold_left (fun acc e -> acc + count_let_bindings_prefix prefix e) 0 args
   | EFun (_, body, _) -> count_let_bindings_prefix prefix body
   | EApp (fn, args, _) ->
@@ -84,7 +84,7 @@ let rec first_ife_branches = function
                   | None -> search rest)
             in
             search branches)
-  | EConst _ | EVar _ -> None
+  | EConst _ | EVar _ | EError _ -> None
 
 
 let extract_single_case_branch_body = function

--- a/src/test/test_rizzo.ml
+++ b/src/test/test_rizzo.ml
@@ -101,7 +101,7 @@ let ann_has_tvar : type s. s Ast.ann -> bool = function
   | Ast.Ann_parsed _ | Ast.Ann_bound _ -> false
 
 let rec pattern_has_tvar : type s. s Ast.pattern -> bool = function
-  | Ast.PWildcard ann | Ast.PConst (_, ann) | Ast.PVar (_, ann) -> ann_has_tvar ann
+  | Ast.PWildcard ann | Ast.PConst (_, ann) | Ast.PVar (_, ann) | Ast.PError (_, ann) -> ann_has_tvar ann
   | Ast.PTuple (p1, p2, ann) -> ann_has_tvar ann || pattern_has_tvar p1 || pattern_has_tvar p2
   | Ast.PSigCons (p1, (_, ann2), ann) | Ast.PStringCons (p1, (_, ann2), ann) ->
       ann_has_tvar ann || ann_has_tvar ann2 || pattern_has_tvar p1
@@ -110,6 +110,7 @@ let rec pattern_has_tvar : type s. s Ast.pattern -> bool = function
 
 let rec expr_has_tvar : type s. s Ast.expr -> bool = function
   | Ast.EConst (_, ann) -> ann_has_tvar ann
+  | Ast.EError (_, ann) -> ann_has_tvar ann
   | Ast.EVar (_, ann) -> ann_has_tvar ann
   | Ast.ECtor ((_, ctor_ann), args, ann) ->
       ann_has_tvar ctor_ann || ann_has_tvar ann || List.exists expr_has_tvar args

--- a/src/test/test_strings.ml
+++ b/src/test/test_strings.ml
@@ -13,7 +13,7 @@ let parse_and_typecheck input =
 
 let rec expr_contains_case : _ expr -> bool = function
   | ECase _ -> true
-  | EConst _ | EVar _ -> false
+  | EConst _ | EVar _ | EError _ -> false
   | ECtor (_, args, _) -> List.exists expr_contains_case args
   | ELet (_, rhs, body, _) -> expr_contains_case rhs || expr_contains_case body
   | EFun (_, body, _) -> expr_contains_case body
@@ -26,7 +26,7 @@ let rec expr_contains_case : _ expr -> bool = function
 
 let rec expr_contains_call target : _ expr -> bool = function
   | EApp (EVar (name, _), _, _) when String.equal name target -> true
-  | EConst _ | EVar _ -> false
+  | EConst _ | EVar _ | EError _ -> false
   | ECtor (_, args, _) -> List.exists (expr_contains_call target) args
   | ELet (_, rhs, body, _) -> expr_contains_call target rhs || expr_contains_call target body
   | EFun (_, body, _) -> expr_contains_call target body
@@ -43,7 +43,7 @@ let rec expr_contains_call target : _ expr -> bool = function
 let rec expr_contains_let_binding target : _ expr -> bool = function
   | ELet ((name, _), rhs, body, _) ->
     String.equal name target || expr_contains_let_binding target rhs || expr_contains_let_binding target body
-  | EConst _ | EVar _ -> false
+  | EConst _ | EVar _ | EError _ -> false
   | ECtor (_, args, _) -> List.exists (expr_contains_let_binding target) args
   | EFun (_, body, _) -> expr_contains_let_binding target body
   | EApp (fn, args, _) -> expr_contains_let_binding target fn || List.exists (expr_contains_let_binding target) args


### PR DESCRIPTION

This pull request introduces robust support for parse error reporting in the AST and parser. It adds new `EError` and `PError` nodes to the core AST, updates the parser to generate these nodes for common syntax errors, and ensures all downstream consumers (pretty-printer, equality, language service, and transformations) handle these cases gracefully. This will improve error messages and IDE integration for incomplete or incorrect code.

### AST Extensions for Error Handling
* Added `EError` and `PError` constructors to the core AST types in `ast_core.ml` to represent expressions and patterns with parse errors, and updated all relevant pattern-matching code to handle these new cases. [[1]](diffhunk://#diff-cc3d842996d6e88ccd1bf3339e96e7afc02378fbb7dc13268255316afbb606bdR58-R66) [[2]](diffhunk://#diff-cc3d842996d6e88ccd1bf3339e96e7afc02378fbb7dc13268255316afbb606bdL112-R117) [[3]](diffhunk://#diff-cc3d842996d6e88ccd1bf3339e96e7afc02378fbb7dc13268255316afbb606bdR128)

### Parser Improvements
* Updated the parser (`parser.mly`) to generate `EError` nodes for missing expressions in `let`, `if-then-else`, and `match` constructs, and for missing match case bodies, providing more precise syntax error localization. [[1]](diffhunk://#diff-8278aa70242f94464f683193c4f6cef74f91623913009dcca7adfb8bdbdd3a70R39-R41) [[2]](diffhunk://#diff-8278aa70242f94464f683193c4f6cef74f91623913009dcca7adfb8bdbdd3a70R148-R185) [[3]](diffhunk://#diff-8278aa70242f94464f683193c4f6cef74f91623913009dcca7adfb8bdbdd3a70R195-R211)

### Pretty-Printing and Equality
* Updated the pretty-printer (`ast_pp.ml`) to display parse errors in red and the equality module (`ast_eq.ml`) to compare error nodes by their messages, ensuring errors are visible and comparable. [[1]](diffhunk://#diff-ce258cb67bbcc1d8dd67b58a403e9d2752013514b0c33e339590f3531d388b6dR14) [[2]](diffhunk://#diff-ce258cb67bbcc1d8dd67b58a403e9d2752013514b0c33e339590f3531d388b6dR30) [[3]](diffhunk://#diff-ce258cb67bbcc1d8dd67b58a403e9d2752013514b0c33e339590f3531d388b6dR118) [[4]](diffhunk://#diff-d287958897f93e9e18163cc155a2f52b33af9d602841396349acfb558defd777R6) [[5]](diffhunk://#diff-d287958897f93e9e18163cc155a2f52b33af9d602841396349acfb558defd777R31)

### Language Service and Analysis
* Updated the language service (`language_service.ml`) to support the new error nodes in all relevant traversals, including hover text, completions, symbol analysis, and semantic tokens, so that tools and IDE features gracefully handle and report parse errors. [[1]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL467-R467) [[2]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bR578) [[3]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL597-R598) [[4]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL609-R610) [[5]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL621-R622) [[6]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL651-R652) [[7]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL663-R664) [[8]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bR688) [[9]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL817-R819) [[10]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL1049-R1051) [[11]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL1238-R1240) [[12]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL1431-R1433) [[13]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL1771-R1773) [[14]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bL1938-R1940) [[15]](diffhunk://#diff-e6cbfb4dea1834003979c6d4768337e49429b6a7275025f2e0e7f76e6f16f75bR1990-R1994)

### Transformation Passes
* Updated the ANF transformation (`anf.ml`) to treat `EError` as a simple value, ensuring error nodes are preserved through normalization.

These changes together provide end-to-end support for parse error recovery and reporting, making the language tooling more robust and user-friendly.